### PR TITLE
Tactical_1.4.4_changes 

### DIFF
--- a/addons/danger/functions/fnc_assault.sqf
+++ b/addons/danger/functions/fnc_assault.sqf
@@ -19,13 +19,13 @@ _unit setUnitPosWeak "UP";
 // Near buildings + sort near positions + add target actual location
 _buildings = [_target, _range, true, true] call FUNC(nearBuildings);
 _buildings pushBack (getPosATL _target);
-_buildings = _buildings select { _x distance2d _target < 5 };
+_buildings = _buildings select { _x distance2d _target < ( 4 + random 3 ) };
 
 // exit without buildings? -- Assault or delay!
 if (count _buildings < 2 || { random 1 > 0.8 }) exitWith {
 
     // Outdoors or indoors with 5% chance to move out
-    if (!(_unit call FUNC(indoor)) || { random 1 > 0.95 }) then {
+    if (!(_unit call FUNC(indoor)) || { random 1 > 0.8 }) then {
         // execute move
         _unit doMove (_unit getHideFrom _target);
         //_unit moveTo (_unit getHideFrom _target); //-- testing moveTo for lower level order

--- a/addons/danger/functions/fnc_checkBody.sqf
+++ b/addons/danger/functions/fnc_checkBody.sqf
@@ -32,11 +32,15 @@ if (count _body > 0) exitWith {
 
     // do it
     [_unit,_body] spawn {
-        params ["_unit","_body","_bodyPos"];
+        params ["_unit","_body","_bodyPos","_time"];
         _bodyPos = getPosATL _body;
         _unit doMove _bodyPos;
-        waitUntil {(_unit distance _bodyPos < 0.5) || {_unit getVariable [QGVAR(lastAction),0] < time} || {!alive _unit}};
-        if (alive _unit && {!isNil str _body} && {_unit distance _bodyPos < 0.4}) then {_unit action ["rearm",_body];};
+        _time = time + 20;
+        waitUntil {(_unit distance _bodyPos < 0.6) || {_time < time} || {!alive _unit}};
+        if (alive _unit && {!isNil str _body} && {_unit distance _bodyPos < 0.4}) then {
+            _unit action ["rearm",_body];
+            _unit doFollow leader group _unit;
+        };
     };
 
     // update variable

--- a/addons/danger/functions/fnc_hideInside.sqf
+++ b/addons/danger/functions/fnc_hideInside.sqf
@@ -41,7 +41,7 @@ if (count _buildings > 0 && {random 1 > 0.05}) then {
     // Get General Target Position
     private _targetPos = (_unit getPos [50 + random _range, (_danger getDir _unit) + 45 - random 90]);
     // Find Surrounding Bushes and Rocks
-    private _objs = nearestTerrainObjects [_newPos, ["BUSH", "TREE", "SMALL TREE", "HIDE"], 13, false, true];
+    private _objs = nearestTerrainObjects [_targetPos, ["BUSH", "TREE", "SMALL TREE", "HIDE"], 13, false, true];
     if !(_objs isEqualTo []) then {
         // if a Rock or Bush is found set it as target Pos
         _targetPos = getPos (selectRandom _objs);

--- a/addons/danger/functions/fnc_hideInside.sqf
+++ b/addons/danger/functions/fnc_hideInside.sqf
@@ -17,9 +17,11 @@ if (_buildings isEqualTo []) then {
 // alreayd inside -- exit
 if (_unit call FUNC(indoor)) exitWith {
     if (stance _unit isEqualTo "STAND") then {_unit setUnitPosWeak "MIDDLE"};
+    _unit doWatch _danger;
     false
 };
 
+// variables
 _unit setVariable [QGVAR(currentTarget), _danger];
 _unit setVariable [QGVAR(currentTask), "Hide"];
 
@@ -28,6 +30,7 @@ _unit forceSpeed selectRandom [-1,24,25];
 
 // Randomly scatter into buildings or hide!
 if (count _buildings > 0 && {random 1 > 0.05}) then {
+    _unit setVariable [QGVAR(currentTask), "Hide (inside)"];
     doStop _unit;
     _unit doMove ((selectRandom _buildings) vectorAdd [0.7 - random 1.4,0.7 - random 1.4,0]);
     _unit setUnitPosWeak "MIDDLE";
@@ -38,7 +41,7 @@ if (count _buildings > 0 && {random 1 > 0.05}) then {
     // Get General Target Position
     private _targetPos = (_unit getPos [50 + random _range, (_danger getDir _unit) + 45 - random 90]);
     // Find Surrounding Bushes and Rocks
-    private _objs = nearestTerrainObjects [_targetPos, ["BUSH", "TREE", "SMALL TREE", "HIDE"], 7, false, true];
+    private _objs = nearestTerrainObjects [_newPos, ["BUSH", "TREE", "SMALL TREE", "HIDE"], 13, false, true];
     if !(_objs isEqualTo []) then {
         // if a Rock or Bush is found set it as target Pos
         _targetPos = getPos (selectRandom _objs);

--- a/addons/danger/functions/fnc_leaderAssess.sqf
+++ b/addons/danger/functions/fnc_leaderAssess.sqf
@@ -25,7 +25,7 @@ _unit setVariable [QGVAR(currentTarget), objNull];
 _unit setVariable [QGVAR(currentTask), "Leader Assess"];
 
 // update minimum delay
-[_unit,99,30] call FUNC(leaderModeUpdate);
+[_unit,99,66] call FUNC(leaderModeUpdate);
 
 // leadership assessment
 if (count _enemy > 0) then {
@@ -55,7 +55,7 @@ if (count _enemy > 0) then {
 };
 
 // Check nearby houses?
-if (random 1 > 0.4 && {_unit distance (nearestBuilding _pos) < 25}) then {
+if (random 1 > 0.4 && {_unit distance (nearestBuilding _pos) < 80}) then {
         [_unit,4,_pos] call FUNC(leaderMode);
 };
 
@@ -73,10 +73,18 @@ _weapons = _weapons select {locked _x != 2 && {(_x emptyPositions "Gunner") > 0}
 _units = units group _unit select {unitReady _x && {_x distance2d _pos < 70}};
 
 if (count _weapons > 0 && {count _units > 0}) then {
+    
+    // pick a random unit 
     _units = selectRandom _units;
-    _unit doWatch ObjNull;
-    _units assignAsGunner (selectRandom _weapons);
+    _weapons = selectRandom _weapons; 
+    
+    // asign no target 
+    _units doWatch ObjNull;
+
+    // order to man the vehicle 
+    _units assignAsGunner _weapons;
     [_units] orderGetIn true;
+    group _unit addVehicle _weapons;
 };
 
 // end

--- a/addons/danger/functions/fnc_shareInformation.sqf
+++ b/addons/danger/functions/fnc_shareInformation.sqf
@@ -36,12 +36,11 @@ _range = [rank _unit,_range,_override] call {
     _range
 };
 
-
 // limit by viewdistance
 _range = _range min viewDistance;
 
 // find units
-private _grp = allGroups select {local _x && {side _x isEqualTo side _unit} && {leader _x distance2d _unit < _range} && {_x != group _unit}};
+private _grp = allGroups select {local _x && {side _x isEqualTo side _unit} && {leader _x distance2d _unit < _range} && {_x != group _unit} && {!(behaviour _x isEqualTo "CARELESS")}};
 
 // share information
 {

--- a/addons/danger/functions/fnc_shareInformation.sqf
+++ b/addons/danger/functions/fnc_shareInformation.sqf
@@ -40,7 +40,7 @@ _range = [rank _unit,_range,_override] call {
 _range = _range min viewDistance;
 
 // find units
-private _grp = allGroups select {local _x && {side _x isEqualTo side _unit} && {leader _x distance2d _unit < _range} && {_x != group _unit} && {!(behaviour _x isEqualTo "CARELESS")}};
+private _grp = allGroups select {local _x && {side _x isEqualTo side _unit} && {leader _x distance2d _unit < _range} && {_x != group _unit} && {!(behaviour leader _x isEqualTo "CARELESS")}};
 
 // share information
 {

--- a/addons/danger/functions/fnc_shareInformation.sqf
+++ b/addons/danger/functions/fnc_shareInformation.sqf
@@ -36,6 +36,10 @@ _range = [rank _unit,_range,_override] call {
     _range
 };
 
+
+// limit by viewdistance
+_range = _range min viewDistance;
+
 // find units
 private _grp = allGroups select {local _x && {side _x isEqualTo side _unit} && {leader _x distance2d _unit < _range} && {_x != group _unit}};
 

--- a/addons/danger/functions/fnc_suppress.sqf
+++ b/addons/danger/functions/fnc_suppress.sqf
@@ -15,6 +15,11 @@ _unit setVariable [QGVAR(currentTask), "Suppress"];
 // do it!
 _unit doSuppressiveFire ((AGLToASL _pos) vectorAdd [0,0,0.2 + random 1.2]);
 
+// extend suppressive fire for machineguns
+if (_unit ammo (currentWeapon _unit) > 32) then {
+    _unit suppressFor (2 + random 7);
+};
+
 // debug
 if (GVAR(debug_functions)) then {systemchat format ["%1 Suppression (%2 @ %3m)",side _unit,name _unit,round (_unit distance _pos)];};
 

--- a/addons/danger/functions/fnc_vehicleJink.sqf
+++ b/addons/danger/functions/fnc_vehicleJink.sqf
@@ -9,31 +9,39 @@ params ["_unit",["_range",25 + random [0,25,150]]];
 // settings
 private _veh = vehicle _unit;
 
+// cannot move or moving
+if (!canMove _veh || {currentCommand _veh isEqualTo "MOVE" || currentCommand _veh isEqualTo "ATTACK"}) exitWith {getPosASL _unit};
+
+// variables
 _unit setVariable [QGVAR(currentTarget), objNull];
 _unit setVariable [QGVAR(currentTask), "Jink Vehicle"];
+
+// Find positions
+private _destination = [];
+_destination pushBack (_veh modelToWorldVisual [_range,-(random 10),0]);
+_destination pushBack (_veh modelToWorldVisual [_range * -1,-(random 10),0]);
+//_destination pushBack (_veh modelToWorldVisual [0,(20 + random 50) * -1,0]);  <-- rear movement just confuses AI
+
+// near enemy?
+if (!isNull (_unit findNearestEnemy _unit)) then {
+    _destination pushBack ([getpos (_unit findNearestEnemy _unit), 120 + _range, _range, 8,getpos _veh] call BIS_fnc_findOverwatch);
+};
+
+// tweak
+_destination apply {_x findEmptyPosition [0,25,typeOf _veh];};
+
+// actual position and no water
+_destination = _destination select {count _x > 0 && {!(surfaceIsWater _x)}};
+
+// check -- no location -- exit
+if (count _destination < 1) exitWith {_veh modelToWorldVisual [0,-(random 30),0]};
+_destination = selectRandom _destination; 
 
 // refresh ready
 effectiveCommander _unit doMove getPosASL _unit;
 
-// fnc find good spot
-private _destination = selectBestPlaces [_veh getRelPos [_range, selectRandom [90,90,270,270,180]], 50,"(1 + hills) * (1 + meadow) *  (1 - sea)",100,2] apply {_x select 0};
-
-// flat
-//_destination = _destination apply {_p2 = [_x,0,100,3,0,0.12,0,[],[_x,_x]] call BIS_fnc_findSafePos;_p2};
-
-// always getPos
-_destination pushBack (_veh modelToWorldVisual [_range,0,0]);
-_destination pushBack (_veh modelToWorldVisual [_range * -1,0,0]);
-
-// no water
-_destination = _destination select {!(surfaceIsWater _x)};
-
-// check -- no location -- exit
-if (count _destination < 1) exitWith {getPosASL _veh};
-_destination = selectRandom _destination;
-
 // execute
-_veh doMove _destination;
+_veh doMove  _destination;
 
 // debug
 if (GVAR(debug_functions)) then {systemchat format ["%1 jink (%2 moves %3m)",side _unit,getText (configFile >> "CfgVehicles" >> (typeOf vehicle _unit) >> "displayName"),round (_unit distance _destination)];};

--- a/addons/danger/functions/fnc_vehicleRotate.sqf
+++ b/addons/danger/functions/fnc_vehicleRotate.sqf
@@ -21,7 +21,7 @@
 // init
 params ["_unit",["_target", []],["_threshold",18]];
 
-if (_targets isEqualTo []) then {
+if (_target isEqualTo []) then {
     _target = _unit findNearestEnemy _unit;
 };
 

--- a/addons/danger/scripts/lambs_danger.fsm
+++ b/addons/danger/scripts/lambs_danger.fsm
@@ -1,4 +1,4 @@
-/*%FSM<COMPILE "H:\SteamLibrary\steamapps\common\Arma 3 Tools\FSMEditor\scriptedFSM.cfg, Danger">*/
+/*%FSM<COMPILE "scriptedFSM.cfg, Danger">*/
 /*%FSM<HEAD>*/
 /*
 item0[] = {"Player_or__not_l",4,218,1025.000000,-525.000000,1150.000000,-450.000000,12.000000,"Player or " \n "not local"};
@@ -71,14 +71,16 @@ item66[] = {"Pre_attack",2,250,25.000000,75.000000,125.000000,125.000000,0.00000
 item67[] = {"Always",4,218,-50.000000,150.000000,50.000000,200.000000,0.000000,"Always"};
 item68[] = {"Coward",4,218,50.000000,150.000000,150.000000,200.000000,1.000000,"Coward"};
 item69[] = {"Coward",2,250,50.000000,225.000000,150.000000,275.000000,0.000000,"Coward"};
-item70[] = {"Clear_buildings",2,250,150.000000,225.000000,250.000000,275.000000,0.000000,"Clear buildings"};
-item71[] = {"Cycle_",4,218,200.000000,325.000000,300.000000,375.000000,1.000000,"Cycle!"};
+item70[] = {"Clear_buildings",2,4346,150.000000,225.000000,250.000000,275.000000,0.000000,"Clear buildings"};
+item71[] = {"Cycle_",4,218,225.000000,325.000000,325.000000,375.000000,1.000000,"Cycle!"};
 item72[] = {"",7,210,-466.500000,-54.000000,-458.500000,-46.000000,0.000000,""};
 item73[] = {"Static",4,218,-1025.000000,25.000000,-925.000000,75.000000,1.000000,"Static"};
 item74[] = {"Suppression",2,250,-1025.000000,150.000000,-925.000000,200.000000,0.000000,"Suppression"};
 item75[] = {"LEADER_EVALUATIONS",-1,250,575.000000,25.000000,800.000000,75.000000,0.000000,"LEADER EVALUATIONS AND ACTIONS"};
 item76[] = {"Close_Quarters_C",-1,250,175.000000,75.000000,300.000000,125.000000,0.000000,"Close" \n "Quarters" \n "Combat"};
-item77[] = {"____VARIABLES__lambs",-1,250,-1630.300171,-578.637817,-1293.179321,-406.645874,0.000000,"// VARIABLES " \n "lambs_danger_inCQB" \n "lambs_danger_lastAction" \n "lambs_danger_isChecked" \n "lambs_danger_dangerMode" \n "lambs_danger_dangerFormation" \n "lambs_danger_dangerCode" \n "lambs_danger_dangerAI" \n "" \n "// VARIABLES ~ debug" \n "lambs_danger_currentTarget" \n "lambs_danger_currentTask" \n "lambs_danger_lambs_danger_FSMDangerCauseData"};
+item77[] = {"____VARIABLES__lambs",-1,250,-1625.000000,-575.000000,-1300.000000,-250.000000,0.000000,"" \n "// VARIABLES " \n "lambs_danger_inCQB" \n "lambs_danger_lastAction" \n "lambs_danger_isChecked" \n "lambs_danger_dangerMode" \n "lambs_danger_dangerFormation" \n "lambs_danger_dangerCode" \n "lambs_danger_dangerAI" \n "" \n "// VARIABLES ~ debug" \n "lambs_danger_currentTarget" \n "lambs_danger_currentTask" \n "lambs_danger_lambs_danger_FSMDangerCauseData"};
+item78[] = {"LAMBS_DANGER_FSM",-1,250,-1700.000000,-925.000000,-800.000000,-800.000000,0.000000,"LAMBS DANGER FSM 1.5.0"};
+item79[] = {"Player_formation",4,218,175.000000,350.000000,275.000000,400.000000,0.000000,"Player" \n "formationleader"};
 version=1;
 class LayoutItems
 {
@@ -128,6 +130,15 @@ class LayoutItems
 			FontHeight=10;
 			lStyle=1;
 			Align=0;
+		};
+	};
+	class Item78
+	{
+		class ItemInfo
+		{
+			FontFace="Arial";
+			FontHeight=20;
+			lStyle=1;
 		};
 	};
 };
@@ -225,12 +236,14 @@ link90[] = {68,69};
 link91[] = {69,26};
 link92[] = {70,26};
 link93[] = {70,71};
-link94[] = {71,70};
-link95[] = {72,4};
-link96[] = {73,74};
-link97[] = {74,18};
-globals[] = {0.000000,0,0,0,0,640,480,2,398,6316128,1,-1763.453369,-919.400635,-87.589478,-773.378967,1088,884,1};
-window[] = {2,-1,-1,-1,-1,865,52,854,52,3,1106};
+link94[] = {70,79};
+link95[] = {71,70};
+link96[] = {72,4};
+link97[] = {73,74};
+link98[] = {74,18};
+link99[] = {79,29};
+globals[] = {0.000000,0,0,0,0,640,480,2,400,6316128,1,-383.016113,520.118774,626.818359,-106.978394,1088,884,1};
+window[] = {2,-1,-1,-1,-1,891,78,880,78,3,1106};
 *//*%FSM</HEAD>*/
 class FSM
 {
@@ -479,7 +492,7 @@ class FSM
                                         priority = 3.000000;
                                         to="Investigate__Unload";
                                         precondition = /*%FSM<CONDPRECONDITION""">*/""/*%FSM</CONDPRECONDITION""">*/;
-                                        condition=/*%FSM<CONDITION""">*/"_investigate && {_commander}"/*%FSM</CONDITION""">*/;
+                                        condition=/*%FSM<CONDITION""">*/"_investigate && {_commander} && {!_tank}"/*%FSM</CONDITION""">*/;
                                         action=/*%FSM<ACTION""">*/""/*%FSM</ACTION""">*/;
                                 };
                                 /*%FSM</LINK>*/
@@ -517,7 +530,7 @@ class FSM
                          "if (lambs_danger_debug_FSM) then {systemchat format [""%1 - Danger! - %2"",side _this,_dangerCause call lambs_danger_fnc_debugDangerType]};" \n
                          "" \n
                          "// immediate action" \n
-                         "if ((_dangerCause isEqualTo 2)  && {random 1 > 0.65}) then {" \n
+                         "if ((_dangerCause isEqualTo 2)  && {random 1 > 0.6}) then {" \n
                          "	[_this] call lambs_danger_fnc_immediateAction;" \n
                          "}; " \n
                          "" \n
@@ -696,8 +709,7 @@ class FSM
                 {
                         name = "Panic_";
                         itemno = 22;
-                        init = /*%FSM<STATEINIT""">*/"// Panic happens here" \n
-                         "" \n
+                        init = /*%FSM<STATEINIT""">*/"" \n
                          "// suppression code " \n
                          "_delay = [_this,_dangerCausedBy] call lambs_danger_fnc_panic; " \n
                          "" \n
@@ -895,6 +907,7 @@ class FSM
                          "	private _buildings = [_this,45,true,true] call lambs_danger_fnc_nearBuildings;" \n
                          "	{" \n
                          "		[_x,_dangerPos,45,_buildings] call lambs_danger_fnc_hideInside;" \n
+                         "		_timeout = _timeout + 3; " \n
                          "		true" \n
                          "	} count ((units group _this) select {_x distance2d _this < 80 && {unitReady _x} && {isNull objectParent _x}}); " \n
                          "} else {" \n
@@ -949,13 +962,9 @@ class FSM
                 {
                         name = "Investigate";
                         itemno = 34;
-                        init = /*%FSM<STATEINIT""">*/"// investigation happens here " \n
-                         "" \n
+                        init = /*%FSM<STATEINIT""">*/"" \n
                          "// time out " \n
                          "_timeout = time + 5 + random 4; " \n
-                         "" \n
-                         "// storePos " \n
-                         "private _oldPos = getposATL _this; " \n
                          "" \n
                          "// look at it " \n
                          "_this lookAt _dangerPos; " \n
@@ -1020,9 +1029,7 @@ class FSM
                          "" \n
                          "// join" \n
                          "_this doFollow (leader group _this); " \n
-                         "" \n
-                         "// pos " \n
-                         "_this moveTo _oldPos; "/*%FSM</STATEINIT""">*/;
+                         ""/*%FSM</STATEINIT""">*/;
                         precondition = /*%FSM<STATEPRECONDITION""">*/""/*%FSM</STATEPRECONDITION""">*/;
                         class Links
                         {
@@ -1168,11 +1175,8 @@ class FSM
                         name = "Assess___Continu";
                         itemno = 43;
                         init = /*%FSM<STATEINIT""">*/"" \n
-                         "// storePos " \n
-                         "private _oldPos = getposATL _this; " \n
-                         "" \n
                          "// time out " \n
-                         "_timeout = time  + random 4; " \n
+                         "_timeout = time  + 2 + random 4; " \n
                          "" \n
                          "// leader assessment " \n
                          "[_this,_dangerPos] call lambs_danger_fnc_leaderAssess; " \n
@@ -1221,7 +1225,8 @@ class FSM
                          "[_this,[""gestureFreeze""]] call lambs_danger_fnc_gesture;" \n
                          "" \n
                          "// find target " \n
-                         "_target = (_dangerMode select 1) select 1;" \n
+                         "//_target = (_dangerMode select 1) select 1; <-- disabled. Produced bugged results " \n
+                         "_target = _this findNearestEnemy _this;" \n
                          "" \n
                          "// share information " \n
                          "[_this,_target] call lambs_danger_fnc_shareInformation; " \n
@@ -1268,7 +1273,7 @@ class FSM
                          "_timeout = time + 20 + random 10; " \n
                          "" \n
                          "// clean array " \n
-                         "[_this,_evaluation,70] call lambs_danger_fnc_leaderModeUpdate;" \n
+                         "[_this,_evaluation,120] call lambs_danger_fnc_leaderModeUpdate;" \n
                          "" \n
                          "// find target " \n
                          "_target = (_dangerMode select 1) select 2;" \n
@@ -1366,7 +1371,7 @@ class FSM
                          "_timeout = time + 15 + random 10; " \n
                          "" \n
                          "// clean array " \n
-                         "[_this,_evaluation,30] call lambs_danger_fnc_leaderModeUpdate;" \n
+                         "[_this,_evaluation,70] call lambs_danger_fnc_leaderModeUpdate;" \n
                          "" \n
                          "// find target " \n
                          "_target = (_dangerMode select 1) select 3;" \n
@@ -1416,7 +1421,7 @@ class FSM
                          "_timeout = time + 15 + random 10; " \n
                          "" \n
                          "// clean array " \n
-                         "[_this,_evaluation,10] call lambs_danger_fnc_leaderModeUpdate;" \n
+                         "[_this,_evaluation,30] call lambs_danger_fnc_leaderModeUpdate;" \n
                          "" \n
                          "// find pos" \n
                          "_pos = (_dangerMode select 1) select 3;" \n
@@ -1561,11 +1566,6 @@ class FSM
                          "// timeout " \n
                          "_timeout = _timeout + random 4; " \n
                          "" \n
-                         "// do watch? " \n
-                         "if (!isNull (_this findNearestEnemy _this)) then {" \n
-                         "	vehicle _this doWatch (_this findNearestEnemy _this); " \n
-                         "}; " \n
-                         "" \n
                          "// execute jink " \n
                          "_destination = [_this] call lambs_danger_fnc_vehicleJink; " \n
                          "" \n
@@ -1595,17 +1595,17 @@ class FSM
                         name = "Pre_attack";
                         itemno = 66;
                         init = /*%FSM<STATEINIT""">*/"" \n
-                         "// timeout " \n
+                         "// time out " \n
                          "_timeout = time + 4 + random 4;" \n
                          "" \n
                          "// look at " \n
                          "_this lookAt _dangerCausedBy; " \n
                          "" \n
                          "// assault " \n
-                         "_assault = _this distance2d _dangerPos < (lambs_danger_CQB_range + random 30) && {_this distance2d _dangerCausedBy < 210};" \n
+                         "_assault = _this distance2d _dangerPos < (lambs_danger_CQB_range + random 30) && {_this distance2d _dangerCausedBy < (lambs_danger_CQB_range + 150)};" \n
                          "" \n
                          "// coward" \n
-                         "_coward = [_this,_dangerCausedBy] call lambs_danger_fnc_coward;"/*%FSM</STATEINIT""">*/;
+                         "_coward = (!_CQCmode) && {[_this,_dangerCausedBy] call lambs_danger_fnc_coward};"/*%FSM</STATEINIT""">*/;
                         precondition = /*%FSM<STATEPRECONDITION""">*/""/*%FSM</STATEPRECONDITION""">*/;
                         class Links
                         {
@@ -1652,7 +1652,7 @@ class FSM
                         itemno = 69;
                         init = /*%FSM<STATEINIT""">*/"" \n
                          "// hide " \n
-                         "[_this,_dangerCausedBy] call lambs_danger_fnc_hideInside; " \n
+                         "//[_this,_dangerCausedBy] call lambs_danger_fnc_hideInside; // disabled to reduce break up of squad formation" \n
                          "" \n
                          "// update leader-mode" \n
                          "[_this,2,_dangerCausedby] call lambs_danger_fnc_leaderMode;" \n
@@ -1685,7 +1685,7 @@ class FSM
                         name = "Clear_buildings";
                         itemno = 70;
                         init = /*%FSM<STATEINIT""">*/"" \n
-                         "// timeout " \n
+                         "// time out " \n
                          "_timeout = time + 20;" \n
                          "_timeoutCQC = time + 1 + random 4; " \n
                          "" \n
@@ -1712,6 +1712,17 @@ class FSM
                                         to="Clear_buildings";
                                         precondition = /*%FSM<CONDPRECONDITION""">*/""/*%FSM</CONDPRECONDITION""">*/;
                                         condition=/*%FSM<CONDITION""">*/"unitReady _this || {time > _timeoutCQC}"/*%FSM</CONDITION""">*/;
+                                        action=/*%FSM<ACTION""">*/""/*%FSM</ACTION""">*/;
+                                };
+                                /*%FSM</LINK>*/
+                                /*%FSM<LINK "Player_formation">*/
+                                class Player_formation
+                                {
+                                        itemno = 79;
+                                        priority = 0.000000;
+                                        to="Timeout__Continu";
+                                        precondition = /*%FSM<CONDPRECONDITION""">*/""/*%FSM</CONDPRECONDITION""">*/;
+                                        condition=/*%FSM<CONDITION""">*/"isPlayer formationLeader _this"/*%FSM</CONDITION""">*/;
                                         action=/*%FSM<ACTION""">*/""/*%FSM</ACTION""">*/;
                                 };
                                 /*%FSM</LINK>*/

--- a/addons/danger/scripts/lambs_dangerCivilian.fsm
+++ b/addons/danger/scripts/lambs_dangerCivilian.fsm
@@ -1,9 +1,9 @@
-/*%FSM<COMPILE "H:\SteamLibrary\steamapps\common\Arma 3 Tools\FSMEditor\scriptedFSM.cfg, Danger">*/
+/*%FSM<COMPILE "scriptedFSM.cfg, Danger">*/
 /*%FSM<HEAD>*/
 /*
-item0[] = {"DEFINE_ENUM_BEG",-1,4346,-1200.000000,-360.000000,-860.000000,-180.000000,0.000000,"DEFINE_ENUM_BEG(DangerCause)" \n "0 - DCEnemyDetected, // the first enemy detected" \n "1 - DCFire, // fire visible" \n "2 - DCHit, // vehicle hit" \n "3 - DCEnemyNear, // enemy very close to me" \n "4 - DCExplosion, // explosion detected" \n "5 - DCDeadBodyGroup, // dead soldier from my group found" \n "6 - DCDeadBody, // other dead soldier found" \n "7 - DCScream // hit soldier screaming" \n "DEFINE_ENUM_END(DangerCause)" \n ""};
+item0[] = {"DEFINE_ENUM_BEG",-1,250,-1200.000000,-360.000000,-860.000000,-180.000000,0.000000,"DEFINE_ENUM_BEG(DangerCause)" \n "0 - DCEnemyDetected, // the first enemy detected" \n "1 - DCFire, // fire visible" \n "2 - DCHit, // vehicle hit" \n "3 - DCEnemyNear, // enemy very close to me" \n "4 - DCExplosion, // explosion detected" \n "5 - DCDeadBodyGroup, // dead soldier from my group found" \n "6 - DCDeadBody, // other dead soldier found" \n "7 - DCScream // hit soldier screaming" \n "DEFINE_ENUM_END(DangerCause)" \n ""};
 item1[] = {"Init",0,250,-820.000000,-360.000000,-720.000000,-320.000000,0.000000,"Init"};
-item2[] = {"End",1,250,-100.000000,1200.000000,0.000000,1260.000000,0.000000,"End"};
+item2[] = {"End",1,4346,-100.000000,1200.000000,0.000000,1260.000000,0.000000,"End"};
 item3[] = {"Causes__7",4,218,-840.000000,-60.000000,-700.000000,0.000000,1.000000,"Causes:" \n "7"};
 item4[] = {"Rest",4,218,-100.000000,-160.000000,0.000000,-100.000000,0.000000,"Rest"};
 item5[] = {"Causes__1__2__4",4,218,-620.000000,-60.000000,-500.000000,0.000000,1.000000,"Causes:" \n "1, 2, 4"};
@@ -201,8 +201,8 @@ link75[] = {65,13};
 link76[] = {66,67};
 link77[] = {67,2};
 link78[] = {68,66};
-globals[] = {0.000000,0,0,0,0,640,480,1,213,6316128,1,-1361.025635,-676.242371,75.788635,-541.914185,980,884,1};
-window[] = {2,-1,-1,-32000,-32000,896,78,1242,78,3,998};
+globals[] = {0.000000,0,0,0,0,640,480,1,213,6316128,1,-1804.290039,-132.080322,1955.943970,447.542603,980,884,1};
+window[] = {2,-1,-1,-1,-1,974,156,1320,156,3,998};
 *//*%FSM</HEAD>*/
 class FSM
 {
@@ -307,7 +307,7 @@ class FSM
                         name = "End";
                         itemno = 2;
                         init = /*%FSM<STATEINIT""">*/"_this setBehaviour _behaviour;" \n
-                         "_this setVariable [""DC"",false];"/*%FSM</STATEINIT""">*/;
+                         "_this setVariable [""DC"",false];		// from vanilla. Uncertain what it does "/*%FSM</STATEINIT""">*/;
                         precondition = /*%FSM<STATEPRECONDITION""">*/""/*%FSM</STATEPRECONDITION""">*/;
                         class Links
                         {
@@ -1116,7 +1116,7 @@ class FSM
                 {
                         name = "Debug";
                         itemno = 66;
-                        init = /*%FSM<STATEINIT""">*/"debugLog format [""DC: %1, Action: none"",_dangerCause];"/*%FSM</STATEINIT""">*/;
+                        init = /*%FSM<STATEINIT""">*/""/*%FSM</STATEINIT""">*/;
                         precondition = /*%FSM<STATEPRECONDITION""">*/""/*%FSM</STATEPRECONDITION""">*/;
                         class Links
                         {


### PR DESCRIPTION
changes - fsm
- Clean up of civilian formation.fsm
- Individual coward fn_hideInside function disabled (ID 69)
- Increased 'timeout' on leader assess delay (+2 seconds)(ID 43)
- Removed redundant investigate 'moveto' pos (ID 34 + ID 36)
- Increased leader time out on Reaciton to contact (+ 3 seconds) (ID 32)
- Added break out of CQC cycle for player led groups (ID 399)
- Fixed Use findNearestEnemy on leader CONTACT event (ID 46)
- Increased timeout on Leader hide form target from 70 to 120 seconds. (ID 48)
- Increased time on Leader Manoeuvre from 30 to 70 seconds (ID 53)
- Increased time on leader Check houses from 10 to 30 seconds (ID 55)
- Increased variability on CQC range (ID 66)
- Tweaked No cowardly behaviour in CQC mode (ID 66)
- Increased chance of immediate Action from 35% to 40% (ID 15)
- Removed Tanks from vehicle investigate action (ID 59)
- Tweaked vehicle jink- removed doWatch. Vehicle too busy! (ID 64)

changes - functions
- Increased suppression time for machineguns
- Increased leader assessment delays
- Improved vehicle jink function predictability and use
- Tweaked fn_hideInside bush/rock/tree/hide search range
- Increased fn_assault chance to rush out of building from 5% to 20%
- Increased fuzziness to fn_assault building pos sorting from 5m - 4-7m
- Increased fn_leaderAssess building range check from 20 to 80m
- Improved fn_leaderAssess man static weapons
- Improved checkBody behaviour
- Tweaked limit fn_shareInformation range by view distance (This can be discussed. I have found it more sensible to gameplay)