### PR TITLE
Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,40 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ""
+labels: bug
+assignees: ""
+---
+
+**Mods (complete and add to the following information):**
+
+- **Arma 3:** `x.xx` [e.g. 1.00 stable, rc, dev]
+- **CBA:** `3.x.x` [e.g. 3.0.0 stable]
+- **LAMBS_DANGER:** `1.x.x` [eg. 1.5.0 stable]
+  _Make sure to reproduce the issue with only CBA and LAMBS_DANGER on a newly created mission!_
+
+**Description:**
+
+A clear and concise description of what the bug is.
+
+**Steps to reproduce:**
+
+- Go to ...
+- Click ...
+- See ...
+
+**Expected behavior:**
+
+A clear and concise description of what you expected to happen.
+
+**Where did the issue occur?**
+
+- Dedicated / Self-Hosted Multiplayer / Singleplayer / Editor (Singleplayer) / Editor (Multiplayer) / Virtual Arsenal
+
+**Additional context:**
+
+Add any other context about the problem here.
+
+**Screenshots:**
+
+If applicable, add screenshots to help explain your problem.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -29,7 +29,7 @@ A clear and concise description of what you expected to happen.
 
 **Where did the issue occur?**
 
-- Dedicated / Self-Hosted Multiplayer / Singleplayer / Editor (Singleplayer) / Editor (Multiplayer) / Virtual Arsenal
+- Dedicated / Self-Hosted Multiplayer / Singleplayer / Editor (Singleplayer) / Editor (Multiplayer)
 
 **Additional context:**
 

--- a/.github/ISSUE_TEMPLATE/enhancement_request.md
+++ b/.github/ISSUE_TEMPLATE/enhancement_request.md
@@ -1,0 +1,23 @@
+---
+name: Enhancement request
+about: Suggest an improvement for this project
+title: ""
+labels: enhancement
+assignees: ""
+---
+
+**Is your enhancement related to a problem?**
+
+A clear and concise description of what the enhancement entails. Ex. [...] would improve user experience.
+
+**Solution you'd like:**
+
+A clear and concise description of what you want to happen.
+
+**Alternatives you've considered:**
+
+A clear and concise description of any alternative solutions or ideas you've considered.
+
+**Additional context:**
+
+Add any other context or screenshots about the enhancement here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,11 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ""
+labels: feature request
+assignees: ""
+---
+
+**Describe your requested feature**
+
+Describe your feature request. It is best to go into detail and provide as much information and maybe even pictures.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,4 @@
+### When merged this pull request will:
+
+1. *Describe what this pull request will do*
+2. *Each change in a seperate line*


### PR DESCRIPTION
Issue templates are for creating issues on this repo. People will be able to choose from 4 options.

- Bug report
- Enhancement request
- Feature request
- Regular issue

This should make it easier for when ever people will submit issues. The regular issue option is just a normal issue as you could do it at the moment.

One thing. I am  NOT sure if this PR will enable custom issue templates or not. Maybe they need to enabled by @nk3nny in this repos settings. I am not sure.