### PR TITLE
Add friendlies check to fnc_suppress.sqf

### DIFF
--- a/addons/danger/functions/fnc_suppress.sqf
+++ b/addons/danger/functions/fnc_suppress.sqf
@@ -35,6 +35,8 @@ if (
 if (!_override) then {
     private _enemy = _unit findNearestEnemy (ASLToAGL _pos);
     if (isNull _enemy) exitWith {};
+    private _friendly = _enemy findNearestEnemy _enemy;
+    if (_friendly distance enemy < QVAR(minimaldistance) && _friendly != _unit) exitwith {};
     _pos = ATLToASL (_unit getHideFrom _enemy);
     private _vis = lineIntersectsSurfaces [eyePos _unit, _pos, _unit, vehicle _unit, true, 1];
     if !(_vis isEqualTo []) then {_pos = (_vis select 0) select 0;};


### PR DESCRIPTION
Added check for friendly units nearby - if they're stopping function. If the closest friendly is unit which is suppressing then ignoring the check.

Solution is not perfect, may stop function after detecting common enemy of the target and unit.