### PR TITLE
Task Artillery Register Multible Side Register Issue

### DIFF
--- a/addons/wp/XEH_preInit.sqf
+++ b/addons/wp/XEH_preInit.sqf
@@ -5,10 +5,12 @@ ADDON = false;
 
 if (isServer) then {
     [QGVAR(RegisterArtillery), {
-        private _artillery = [GVAR(SideArtilleryHash), side (_this select 0)] call CBA_fnc_hashGet;
-        _artillery append _this;
-        _artillery = _artillery arrayIntersect _artillery;
-        GVAR(SideArtilleryHash) = [GVAR(SideArtilleryHash), side (_this select 0), _artillery] call CBA_fnc_hashSet;
+        {
+            private _artillery = [GVAR(SideArtilleryHash), side _x] call CBA_fnc_hashGet;
+            _artillery pushBackUnique _x;
+            GVAR(SideArtilleryHash) = [GVAR(SideArtilleryHash), side _x, _artillery] call CBA_fnc_hashSet;
+        } forEach _this;
+
         publicVariable QGVAR(SideArtilleryHash);
     }] call CBA_fnc_addEventhandler;
 


### PR DESCRIPTION
### When merged this pull request will:

1. *Fixes that all Units Registered with the function are all assigned the same side*


possible alternative version
the current version is Slower on Multiple entries registered, but because this is only run a select few times there should not be any problem
```sqf
private _tempHash = [[], []];
{
    private _index = (_tempHash select 0) find (side _x);
    if (_index == -1) then {
        _index = (_tempHash select 0) pushBack (side _x);
    };
    ((_tempHash select 1) select _index) pushback _x;
} forEach _this;

{
    private _artillery = [GVAR(SideArtilleryHash), _x] call CBA_fnc_hashGet;
    private _data = ((_tempHash select 1) select _forEachIndex);
    _artillery append _data;
    GVAR(SideArtilleryHash) = [GVAR(SideArtilleryHash), _x, _artillery] call CBA_fnc_hashSet;
} forEach (_tempHash select 0);
```