### PR TITLE
Fixed patrol area size in 'garrizon' waypoint (small typo)

### DIFF
--- a/addons/wp/functions/fnc_taskGarrison.sqf
+++ b/addons/wp/functions/fnc_taskGarrison.sqf
@@ -80,7 +80,7 @@ if (_patrol) then {
     } else {
         private _area2 = +_area;
         _area2 set [0, (_area2 select 0) * 2];
-        _area2 set [0, (_area2 select 1) * 2];
+        _area2 set [1, (_area2 select 1) * 2];
         [_group2, _group2, _radius, 4, _area2, true] call FUNC(taskPatrol);
     };
 };


### PR DESCRIPTION
This change fixes accidental assignment of `_b` size of patrol area to `_a`