### PR TITLE
Fix a issue with the Cache in doCallout

### DIFF
--- a/addons/main/functions/fnc_doCallout.sqf
+++ b/addons/main/functions/fnc_doCallout.sqf
@@ -68,10 +68,7 @@ if (isNil "_cachedSounds") then {
         _protocolConfig = _protocolConfig >> _behavior;
     };
 
-    private _calloutConfigName = ["", _callout] select (isArray (_protocolConfig >> _callout))
-    };
-
-    if (_calloutConfigName == "") exitWith {
+    if (isArray (_protocolConfig >> _callout)) exitWith {
         breakOut QGVAR(doCallout_main);
     };
 

--- a/addons/main/functions/fnc_doCallout.sqf
+++ b/addons/main/functions/fnc_doCallout.sqf
@@ -41,6 +41,24 @@ if (_time >= time) exitWith {
 private _speaker = speaker _unit;
 if (toUpper(_speaker) in ["", "ACE_NOVOICE"]) exitWith {}; // Early Exit if Unit is "Mute"
 
+switch (toLower(_callout)) do {
+    case ("contact"): {
+        _callout = selectRandom ["ContactE_1", "ContactE_2", "ContactE_3", "Danger"];
+    };
+    case ("grenadeout"): {
+        _callout = selectRandom ["ThrowingGrenadeE_1", "ThrowingGrenadeE_2", "ThrowingGrenadeE_3"];
+    };
+    case ("mandown"): {
+        _callout = selectRandom ["ManDownE", "WeLostOneE", "WeGotAManDownE"];
+    };
+    case ("suppress"): {
+        _callout = selectRandom ["CombatGenericE", "CheeringE", "SuppressingE", "Suppressing"]
+    };
+    case ("panic"): {
+        _callout = selectRandom ["HealthSomebodyHelpMe", "HealthNeedHelp", "HealthWounded", "HealthMedic", "CombatGenericE"]
+    };
+};
+
 private _cacheName = format ["%1_%2_%3_%4", QGVAR(callouts), _speaker, _behavior, _callout];
 private _cachedSounds = GVAR(CalloutCacheNamespace) getVariable _cacheName;
 
@@ -50,29 +68,7 @@ if (isNil "_cachedSounds") then {
         _protocolConfig = _protocolConfig >> _behavior;
     };
 
-    private _calloutConfigName = switch (toLower(_callout)) do {
-        case ("contact"): {
-            selectRandom ["ContactE_1", "ContactE_2", "ContactE_3", "Danger"];
-        };
-        case ("grenadeout"): {
-            selectRandom ["ThrowingGrenadeE_1", "ThrowingGrenadeE_2", "ThrowingGrenadeE_3"];
-        };
-        case ("mandown"): {
-            selectRandom ["ManDownE", "WeLostOneE", "WeGotAManDownE"];
-        };
-        case ("suppress"): {
-            selectRandom ["CombatGenericE", "CheeringE", "SuppressingE", "Suppressing"]
-        };
-        case ("panic"): {
-            selectRandom ["HealthSomebodyHelpMe", "HealthNeedHelp", "HealthWounded", "HealthMedic", "CombatGenericE"]
-        };
-        default {
-            if (isArray (_protocolConfig >> _callout)) then {
-                _callout;
-            } else {
-                "";
-            };
-        };
+    private _calloutConfigName = ["", _callout] select (isArray (_protocolConfig >> _callout))
     };
 
     if (_calloutConfigName == "") exitWith {

--- a/addons/main/functions/fnc_doCallout.sqf
+++ b/addons/main/functions/fnc_doCallout.sqf
@@ -52,10 +52,10 @@ switch (toLower(_callout)) do {
         _callout = selectRandom ["ManDownE", "WeLostOneE", "WeGotAManDownE"];
     };
     case ("suppress"): {
-        _callout = selectRandom ["CombatGenericE", "CheeringE", "SuppressingE", "Suppressing"]
+        _callout = selectRandom ["CombatGenericE", "CheeringE", "SuppressingE", "Suppressing"];
     };
     case ("panic"): {
-        _callout = selectRandom ["HealthSomebodyHelpMe", "HealthNeedHelp", "HealthWounded", "HealthMedic", "CombatGenericE"]
+        _callout = selectRandom ["HealthSomebodyHelpMe", "HealthNeedHelp", "HealthWounded", "HealthMedic", "CombatGenericE"];
     };
 };
 
@@ -72,7 +72,7 @@ if (isNil "_cachedSounds") then {
         breakOut QGVAR(doCallout_main);
     };
 
-    _cachedSounds = getArray (_protocolConfig >> _calloutConfigName);
+    _cachedSounds = getArray (_protocolConfig >> _callout);
 
     {
         private _sound = _x;


### PR DESCRIPTION
### When merged this pull request will:

Fixing the Callout Cache behaviour. 
Currently, if we use a Callout Collection we cache the one we choose and only play that one, but we wanted to play differently once every time.