### PR TITLE
Support for group ownership transfer for "taskX" functions

### DIFF
--- a/addons/wp/XEH_postInit.sqf
+++ b/addons/wp/XEH_postInit.sqf
@@ -1,3 +1,4 @@
 #include "script_component.hpp"
 GVAR(TargetIndex) = 0;
 GVAR(ModuleTargets) = [];
+[QGVAR(taskPatrol), {_this call FUNC(taskPatrol)}] call CBA_fnc_addEventHandler;

--- a/addons/wp/XEH_postInit.sqf
+++ b/addons/wp/XEH_postInit.sqf
@@ -1,16 +1,12 @@
 #include "script_component.hpp"
 GVAR(TargetIndex) = 0;
 GVAR(ModuleTargets) = [];
-
+[QGVAR(taskAssault), {_this call FUNC(taskAssault)}] call CBA_fnc_addEventHandler;
+[QGVAR(taskCQB), {_this call FUNC(taskCQB)}] call CBA_fnc_addEventHandler;
+[QGVAR(taskCamp), {_this call FUNC(taskCamp)}] call CBA_fnc_addEventHandler;
+[QGVAR(taskCreep), {_this call FUNC(taskCreep)}] call CBA_fnc_addEventHandler;
 [QGVAR(taskGarrison), {_this call FUNC(taskGarrison)}] call CBA_fnc_addEventHandler;
+[QGVAR(taskHunt), {_this call FUNC(taskHunt)}] call CBA_fnc_addEventHandler;
 [QGVAR(taskPatrol), {_this call FUNC(taskPatrol)}] call CBA_fnc_addEventHandler;
-
-[QGVAR(taskGarrison), {_this call FUNC(taskAssault)}] call CBA_fnc_addEventHandler;
-
-[QGVAR(taskGarrison), {_this call FUNC(taskCQB)}] call CBA_fnc_addEventHandler;
-
-[QGVAR(taskGarrison), {_this call FUNC(taskGarrison)}] call CBA_fnc_addEventHandler;
-
-[QGVAR(taskGarrison), {_this call FUNC(taskGarrison)}] call CBA_fnc_addEventHandler;
-
-[QGVAR(taskGarrison), {_this call FUNC(taskGarrison)}] call CBA_fnc_addEventHandler;
+[QGVAR(taskReset), {_this call FUNC(taskReset)}] call CBA_fnc_addEventHandler;
+[QGVAR(taskRush), {_this call FUNC(taskRush)}] call CBA_fnc_addEventHandler;

--- a/addons/wp/XEH_postInit.sqf
+++ b/addons/wp/XEH_postInit.sqf
@@ -1,4 +1,16 @@
 #include "script_component.hpp"
 GVAR(TargetIndex) = 0;
 GVAR(ModuleTargets) = [];
+
+[QGVAR(taskGarrison), {_this call FUNC(taskGarrison)}] call CBA_fnc_addEventHandler;
 [QGVAR(taskPatrol), {_this call FUNC(taskPatrol)}] call CBA_fnc_addEventHandler;
+
+[QGVAR(taskGarrison), {_this call FUNC(taskAssault)}] call CBA_fnc_addEventHandler;
+
+[QGVAR(taskGarrison), {_this call FUNC(taskCQB)}] call CBA_fnc_addEventHandler;
+
+[QGVAR(taskGarrison), {_this call FUNC(taskGarrison)}] call CBA_fnc_addEventHandler;
+
+[QGVAR(taskGarrison), {_this call FUNC(taskGarrison)}] call CBA_fnc_addEventHandler;
+
+[QGVAR(taskGarrison), {_this call FUNC(taskGarrison)}] call CBA_fnc_addEventHandler;

--- a/addons/wp/functions/fnc_taskAssault.sqf
+++ b/addons/wp/functions/fnc_taskAssault.sqf
@@ -34,7 +34,10 @@ params [
 ];
 
 // sort grp
-if (!local _group) exitWith {false};
+if (!local _group) exitWith {
+    [QGVAR(taskAssault), _this, _group] call CBA_fnc_targetEvent;
+};
+
 _group = _group call CBA_fnc_getGroup;
 _group enableAttack false;
 _group allowFleeing 0;

--- a/addons/wp/functions/fnc_taskCQB.sqf
+++ b/addons/wp/functions/fnc_taskCQB.sqf
@@ -165,7 +165,10 @@ private _fnc_act = {
 // functions end ---
 
 // sort grp
-if (!local _group) exitWith {false};
+if (!local _group) exitWith {
+    [QGVAR(taskCQB), _this, _group] call CBA_fnc_targetEvent;
+};
+
 if (_group isEqualType objNull) then {
     _group = group _group;
 };

--- a/addons/wp/functions/fnc_taskCamp.sqf
+++ b/addons/wp/functions/fnc_taskCamp.sqf
@@ -35,7 +35,10 @@ params [
 if (canSuspend) exitWith { [FUNC(taskCamp), _this] call CBA_fnc_directCall; };
 
 // sort grp
-if (!local _group) exitWith {false};
+if (!local _group) exitWith {
+    [QGVAR(taskCamp), _this, _group] call CBA_fnc_targetEvent;
+};
+
 if (_group isEqualType objNull) then {_group = group _group};
 private _units = (units _group) select {!isPlayer _x && {isNull objectParent _x}};
 

--- a/addons/wp/functions/fnc_taskCamp.sqf
+++ b/addons/wp/functions/fnc_taskCamp.sqf
@@ -84,12 +84,23 @@ if (_patrol) then {
 
     // orders
     if (_area isEqualTo []) then {
-        [_group2, _group2, _range * 2, 4, nil, true] call FUNC(taskPatrol);
+    
+        if (local _group2) then {
+            [_group2, _group2, _range * 2, 4, nil, true] call FUNC(taskPatrol);
+        } else {
+            [QGVAR(taskPatrol), [_group2, _group2, _range * 2, 4, nil, true], _group2] call CBA_fnc_targetEvent;
+        };
+    
     } else {
         private _area2 = +_area;
         _area2 set [0, (_area2 select 0) * 2];
         _area2 set [0, (_area2 select 1) * 2];
-        [_group2, _group2, _range * 2, 4, _area2, true] call FUNC(taskPatrol);
+        
+        if (local _group2) then {
+            [_group2, _group2, _range * 2, 4, _area2, true] call FUNC(taskPatrol);
+        } else {
+            [QGVAR(taskPatrol), [_group2, _group2, _range * 2, 4, _area2, true], _group2] call CBA_fnc_targetEvent;
+        };
     };
 
     // update

--- a/addons/wp/functions/fnc_taskCreep.sqf
+++ b/addons/wp/functions/fnc_taskCreep.sqf
@@ -82,7 +82,10 @@ private _fnc_creepOrders = {
 // functions end ---
 
 // sort grp
-if (!local _group) exitWith {false};
+if (!local _group) exitWith {
+    [QGVAR(taskCreep), _this, _group] call CBA_fnc_targetEvent;
+};
+
 if (_group isEqualType objNull) then { _group = group _group; };
 
 // orders

--- a/addons/wp/functions/fnc_taskGarrison.sqf
+++ b/addons/wp/functions/fnc_taskGarrison.sqf
@@ -39,7 +39,10 @@ params [
 ];
 
 // sort grp
-if (!local _group) exitWith {false};
+if (!local _group) exitWith {
+    [QGVAR(taskGarrison), _this, _group] call CBA_fnc_targetEvent;
+};
+
 if (_group isEqualType objNull) then { _group = group _group; };
 
 // sort pos

--- a/addons/wp/functions/fnc_taskGarrison.sqf
+++ b/addons/wp/functions/fnc_taskGarrison.sqf
@@ -91,12 +91,24 @@ if (_patrol) then {
 
     // orders
     if (_area isEqualTo []) then {
-        [_group2, _group2, _radius, 4, nil, true] call FUNC(taskPatrol);
+    
+        if (local _group2) then {
+            [_group2, _group2, _radius, 4, nil, true] call FUNC(taskPatrol);
+        } else {
+            [QGVAR(taskPatrol), [_group2, _group2, _radius, 4, nil, true], _group2] call CBA_fnc_targetEvent;
+        };
+        
     } else {
+    
         private _area2 = +_area;
         _area2 set [0, (_area2 select 0) * 2];
         _area2 set [1, (_area2 select 1) * 2];
-        [_group2, _group2, _radius, 4, _area2, true] call FUNC(taskPatrol);
+        
+        if (local _group2) then {
+            [_group2, _group2, _radius, 4, _area2, true] call FUNC(taskPatrol);
+        } else {
+            [QGVAR(taskPatrol), [_group2, _group2, _radius, 4, _area2, true], _group2] call CBA_fnc_targetEvent;
+        };
     };
 };
 

--- a/addons/wp/functions/fnc_taskHunt.sqf
+++ b/addons/wp/functions/fnc_taskHunt.sqf
@@ -35,7 +35,10 @@ params [
 ];
 
 // sort grp
-if (!local _group) exitWith {false};
+if (!local _group) exitWith {
+    [QGVAR(taskHunt), _this, _group] call CBA_fnc_targetEvent;
+};
+
 if (_group isEqualType objNull) then { _group = group _group; };
 
 // 2. SET GROUP BEHAVIOR

--- a/addons/wp/functions/fnc_taskPatrol.sqf
+++ b/addons/wp/functions/fnc_taskPatrol.sqf
@@ -34,7 +34,10 @@ params [
 ];
 
 // sort grp
-if (!local _group) exitWith {false};
+if (!local _group) exitWith {
+    [QGVAR(taskPatrol), _this, _group] call CBA_fnc_targetEvent;
+};
+
 if (_group isEqualType objNull) then { _group = group _group; };
 
 // sort pos

--- a/addons/wp/functions/fnc_taskReset.sqf
+++ b/addons/wp/functions/fnc_taskReset.sqf
@@ -20,7 +20,10 @@
 params [["_group", grpNull, [grpNull, objNull]]];
 
 // sort group
-if (!local _group) exitWith {false};
+if (!local _group) exitWith {
+    [QGVAR(taskReset), _this, _group] call CBA_fnc_targetEvent;
+};
+
 if (_group isEqualType objNull) then { _group = group _group; };
 
 // units

--- a/addons/wp/functions/fnc_taskRush.sqf
+++ b/addons/wp/functions/fnc_taskRush.sqf
@@ -74,7 +74,10 @@ private _fnc_rushOrders = {
 // functions end ---
 
 // sort grp
-if (!local _group) exitWith {false};
+if (!local _group) exitWith {
+    [QGVAR(taskRush), _this, _group] call CBA_fnc_targetEvent;
+};
+
 if (_group isEqualType objNull) then { _group = group _group; };
 
 // orders


### PR DESCRIPTION
Hello!
I really like your work and what I would like to be able to do with your mod is transferring groups ownership between headless clients, so that groups that call for taskX functions don't need to remain on the same client. I think that this comes handy in cases where there are a lot of AIs around in dynamic missions with reinforcement spawning, lots of kills etc.

To accomplish this, a simple use of CBA's custom events _should_ do the trick, so I suggest their implementation inside your taskX functions, and from my understandings this should be enough, please correct me if wrong! If I missed something or I did something wrong I really would like to fix it by having a brainstorm together.

Thank you for your time!


When merged this pull request will:
Allow changes in groups ownership between clients for taskX functions, so groups can be transferred on headless clients, for example, freeing the server from (possibly) a lot of AIs.