### PR TITLE
WP - Fix task patrol waypoints being at [0,0,0] for local units

### DIFF
--- a/addons/wp/functions/Modules/fnc_modulePatrol.sqf
+++ b/addons/wp/functions/Modules/fnc_modulePatrol.sqf
@@ -70,10 +70,7 @@ switch (_mode) do {
                         _args params ["_targets", "_logic", "_group"];
                         _data params ["_targetIndex", "_range", "_waypointCount", "_moveWaypoint"];
                         private _target = _targets select _targetIndex;
-                        if !(local _group) then {
-                            _target = getPos _target;
-                        };
-                        [_group, _target, _range, _waypointCount, [], _moveWaypoint] remoteExecCall [QFUNC(taskPatrol), leader _group];
+                        [_group, getPos _target, _range, _waypointCount, [], _moveWaypoint] remoteExecCall [QFUNC(taskPatrol), leader _group];
                         if !(_logic isEqualTo _target) then {
                             deleteVehicle _logic;
                         };


### PR DESCRIPTION
On local units, waypoints were always placed at [0,0,0]

from biki
>The "Call" in remoteExecCall does not mean that the execution of the remote executed function / command will happen right away

so the logic would be deleted (line 75) before the `getPos` ran inside taskPatrol function
