### PR TITLE
Fix running in place with minor performance tweaks

### DIFF
--- a/addons/danger/functions/fnc_brainAssess.sqf
+++ b/addons/danger/functions/fnc_brainAssess.sqf
@@ -49,12 +49,9 @@ if (!(_unit checkAIFeature "PATH")) exitWith {_timeout};
 
 // assigned target
 private _assignedTarget = assignedTarget _unit;
-private _canMove = _unit checkAIFeature "PATH";
 if (
     !isNull _assignedTarget
     && {_unit distance2D _assignedTarget < GVAR(cqbRange)}
-    && {_assignedTarget call EFUNC(main,isAlive)}
-    && {(vehicle _assignedTarget) isKindOf "CAManBase"}
     && {(typeOf _assignedTarget) isNotEqualTo "SuppressTarget"}
 ) exitWith {
     [_unit, _assignedTarget] call EFUNC(main,doAssault);
@@ -65,7 +62,7 @@ if (
 private _groupMemory = (group _unit) getVariable [QEGVAR(main,groupMemory), []];
 
 // sympathetic CQB/suppressive fire
-if (_canMove && {_groupMemory isNotEqualTo []}) exitWith {
+if (_groupMemory isNotEqualTo []) exitWith {
     [_unit, _groupMemory] call EFUNC(main,doAssaultMemory);
     _timeout + 2
 };
@@ -73,19 +70,16 @@ if (_canMove && {_groupMemory isNotEqualTo []}) exitWith {
 // stance
 private _stance = stance _unit;
 if (_stance isEqualTo "STAND") then {_unit setUnitPosWeak "MIDDLE";};
-if (_stance isEqualTo "CROUCH" && {getSuppression _unit > 0}) then {_unit setUnitPosWeak "DOWN";};
-
-// check self
-private _indoor = _unit call EFUNC(main,isIndoor);
+if (_stance isEqualTo "CROUCH" && {getSuppression _unit > 0.9}) then {_unit setUnitPosWeak "DOWN";};
 
 // building
-if (_indoor && {RND(EGVAR(main,indoorMove))}) exitWith {
+if (RND(EGVAR(main,indoorMove)) && {_unit call EFUNC(main,isIndoor)}) exitWith {
     [_unit, _target] call EFUNC(main,doReposition);
     _timeout + 1
 };
 
 // cover
-if (speed _unit < 1 && {_unit distance2D (formationLeader _unit) < 32}) then {
+if ((speed _unit) isEqualTo 0 && {_unit distance2D (leader _unit) < 40}) then {
     [_unit] call EFUNC(main,doCover);
 };
 

--- a/addons/danger/functions/fnc_brainEngage.sqf
+++ b/addons/danger/functions/fnc_brainEngage.sqf
@@ -65,7 +65,7 @@ if (
 if (
     _type in [DANGER_ENEMYDETECTED, DANGER_CANFIRE]
     && {_distance < 800}
-    && {getSuppression _unit < 0.9}
+    && {RND(getSuppression _unit)}
 ) exitWith {
     _unit forceSpeed ([1, 2] select (_type isEqualTo DANGER_ENEMYDETECTED));
     [_unit, ATLtoASL ((_unit getHideFrom _target) vectorAdd [0, 0, random 1])] call EFUNC(main,doSuppress);

--- a/addons/danger/functions/fnc_brainForced.sqf
+++ b/addons/danger/functions/fnc_brainForced.sqf
@@ -52,19 +52,8 @@ if (getSuppression _unit > 0) then {
 
 // attack speed
 if ((currentCommand _unit) isEqualTo "ATTACK") then {
-
-    // attacking
-    private _attackTarget = getAttackTarget _unit;
     _unit setVariable [QEGVAR(main,currentTask), "Attacking", EGVAR(main,debug_functions)];
-
-    // forget dead or incapacitated targets --> exits bad attack routine ~ nkenny
-    if !(_attackTarget call EFUNC(main,isAlive)) exitWith {
-        (group _unit) forgetTarget _attackTarget;
-    };
-
-    // tactical movement speed
-    [_unit, _attackTarget] call EFUNC(main,doAssaultSpeed);
-
+    [_unit, getAttackTarget _unit] call EFUNC(main,doAssaultSpeed);
 };
 
 // end

--- a/addons/danger/functions/fnc_isForced.sqf
+++ b/addons/danger/functions/fnc_isForced.sqf
@@ -18,10 +18,9 @@ params ["_unit"];
 fleeing _unit
 || {_unit getVariable [QGVAR(disableAI), false]}
 || {_unit getVariable [QGVAR(forceMove), false]}
+|| {currentCommand _unit in ["ATTACK", "GET IN", "ACTION", "HEAL", "REARM", "JOIN"]}
 || {!(_unit call EFUNC(main,isAlive))}
 || {(_unit getVariable ["ace_medical_ai_healQueue", []]) isNotEqualTo []}
 || {GVAR(disableAIPlayerGroup) && {isPlayer leader _unit}}
-|| {currentCommand _unit in ["ATTACK", "GET IN", "ACTION", "HEAL", "REARM", "JOIN"]}
 || {(behaviour _unit) isEqualTo "CARELESS"}
-//|| {!(_unit checkAIFeature "PATH")}
 || {!(_unit checkAIFeature "MOVE")}

--- a/addons/danger/functions/fnc_tacticsAssess.sqf
+++ b/addons/danger/functions/fnc_tacticsAssess.sqf
@@ -74,7 +74,6 @@ if !(_enemies isEqualTo [] || {_unitCount < random 3}) then {
 
     // anti-infantry tactics
     _enemies = _enemies select {(vehicle _x) isKindOf "Man"};
-    private _inside = _unit call EFUNC(main,isIndoor);
 
     // Check for artillery ~ NB: support is far quicker now! and only targets infantry
     if (EGVAR(main,Loaded_WP) && {[side _unit] call EFUNC(WP,sideHasArtillery)}) then {
@@ -96,6 +95,7 @@ if !(_enemies isEqualTo [] || {_unitCount < random 3}) then {
     ) exitWith {_plan = [];};
 
     // enemies within X meters of leader and either attacker or unit is inside buildings
+    private _inside = _unit call EFUNC(main,isIndoor);
     private _nearIndoorTarget = _enemies findIf {
         _unit distance2D _x < 25
         && {_inside || {_x call EFUNC(main,isIndoor)}}
@@ -138,8 +138,8 @@ if !(_enemies isEqualTo [] || {_unitCount < random 3}) then {
     };
     if (_farTarget != -1) then {
         // suppress or flank
-        _plan append [TACTICS_SUPPRESS, TACTICS_SUPPRESS, TACTICS_FLANK];
-        if (_speedMode isEqualTo "FULL") then {_plan pushBack TACTICS_ASSAULT;};
+        _plan append [TACTICS_SUPPRESS, TACTICS_FLANK];
+        if (_speedMode isEqualTo "FULL") exitWith {_plan pushBack TACTICS_ASSAULT;};
         _pos = _unit getHideFrom (_enemies select _farTarget);
     };
 

--- a/addons/danger/functions/fnc_tacticsHold.sqf
+++ b/addons/danger/functions/fnc_tacticsHold.sqf
@@ -61,6 +61,9 @@ if (count _units > 2) then {
         };
         if (_deadOrSuppressed != -1) then {
 
+            // set group task
+            _group setVariable [QEGVAR(main,currentTactic), "Holding!", EGVAR(main,debug_functions)];
+
             // set behaviour
             _group setBehaviour "COMBAT";
 

--- a/addons/main/functions/UnitAction/fnc_doAssault.sqf
+++ b/addons/main/functions/UnitAction/fnc_doAssault.sqf
@@ -24,13 +24,9 @@ if (!(_unit checkAIFeature "PATH")) exitWith {false};
 _unit setVariable [QGVAR(currentTarget), _target, GVAR(debug_functions)];
 _unit setVariable [QGVAR(currentTask), "Assault", GVAR(debug_functions)];
 
-// settings
-private _distance2D = _unit distance2D _target;
-private _rangeBuilding = linearConversion [ 0, 150, _distance2D, 3.5, 22, true];
-
 // Near buildings + sort near positions + add target actual location
-private _buildings = [_target, _range, true, true] call FUNC(findBuildings);
-_buildings = _buildings select { _x distance _target < _rangeBuilding };
+private _buildings = [_target, _range, true, false] call FUNC(findBuildings);
+_buildings = _buildings select { _x distance _target < 4 };
 
 // set destination
 private _pos = if (_buildings isEqualTo []) then {
@@ -40,9 +36,8 @@ private _pos = if (_buildings isEqualTo []) then {
         getPosATL _unit
     };
 
-    // select expected location
-    private _hide = _unit getHideFrom _target;
-    if (_hide isEqualTo [0,0,0]) then {getPosATL _target} else {_hide}
+    // select target location
+    getPosATL _target
 } else {
 
     // updates group memory variable
@@ -52,7 +47,7 @@ private _pos = if (_buildings isEqualTo []) then {
     _group setVariable [QGVAR(groupMemory), _groupMemory];
 
     // add unit position to array
-    _buildings pushBack getPosATL _target;
+    _buildings pushBack (getPosATL _target);
 
     // select building position
     selectRandom _buildings
@@ -64,7 +59,7 @@ _unit setUnitPosWeak selectRandom ["UP", "UP", "MIDDLE"];
 
 // execute
 _unit doMove _pos;
-_unit setDestination [_pos, "LEADER PLANNED", _distance2D < 15];
+_unit setDestination [_pos, "LEADER PLANNED", true];
 
 // debug
 if (GVAR(debug_functions)) then {

--- a/addons/main/functions/UnitAction/fnc_doCover.sqf
+++ b/addons/main/functions/UnitAction/fnc_doCover.sqf
@@ -8,19 +8,19 @@
  * 1: position of cover <ARRAY>
  *
  * Return Value:
- * _unit
+ * bool
  *
  * Example:
  * [bob] call lambs_main_fnc_doCover;
  *
  * Public: No
 */
-#define SEARCH_FOR_HIDE 4
+#define SEARCH_FOR_HIDE 6
 
 params ["_unit", ["_pos", [], [[]]]];
 
 // check if stopped
-if (!(_unit checkAIFeature "PATH") || {isForcedWalk _unit}) exitWith {_unit};
+if (!(_unit checkAIFeature "PATH")) exitWith {false};
 
 // find cover
 if (_pos isEqualTo []) then {
@@ -33,7 +33,7 @@ if (_pos isEqualTo []) then {
 };
 
 // force anim
-if (_unit distance2D _pos < 0.8) exitWith {_unit};
+if (_unit distance2D _pos < 0.6) exitWith {false};
 private _direction = _unit getRelDir _pos;
 private _anim = call {
     if (_direction > 315) exitWith {["WalkF", "WalkLF"]};
@@ -44,11 +44,12 @@ private _anim = call {
 };
 
 // prevent run in place
-if (((expectedDestination _unit) select 1) isEqualTo "DoNotPlan") then {_unit moveTo _pos;};
+_unit forceSpeed 0;
+_unit moveTo _pos;
+_unit setDestination [_pos, "FORMATION PLANNED", true];
 
 // do anim
 [_unit, _anim, false] call FUNC(doGesture);       // gesture is not forced to allow cover movement to appear smoother - nkenny
-_unit setDestination [_pos, "FORMATION PLANNED", false];
 
 // end
-_unit
+true

--- a/addons/main/functions/UnitAction/fnc_doDodge.sqf
+++ b/addons/main/functions/UnitAction/fnc_doDodge.sqf
@@ -8,7 +8,7 @@
  * 1: position of dange <ARRAY>
  *
  * Return Value:
- * stance <STRING>
+ * bool
  *
  * Example:
  * [bob] call lambs_main_fnc_doDodge;
@@ -23,31 +23,28 @@ params ["_unit", ["_pos", [0, 0, 0]]];
 // settings
 private _stance = stance _unit;
 private _dir = _unit getRelDir _pos;
+private _still = (speed _unit) isEqualTo 0;
 
 // dodge
 _unit setVariable [QGVAR(currentTask), "Dodge!", GVAR(debug_functions)];
 _unit setVariable [QGVAR(currentTarget), _pos, GVAR(debug_functions)];
 
 // prone override
-if (_stance isEqualTo "PRONE" && {!(_unit call FUNC(isIndoor))}) exitWith {
+if (_still && {_stance isEqualTo "PRONE"} && {!(_unit call FUNC(isIndoor))}) exitWith {
     [_unit, ["EvasiveLeft", "EvasiveRight"] select (_dir > 180), true] call FUNC(doGesture);
     _unit setDestination [[_unit getRelPos [DODGE_DISTANCE, -90], _unit getRelPos [DODGE_DISTANCE, 90]] select (_dir > 180), "FORMATION PLANNED", false];
-    _stance
+    true
 };
 
 // ACE3 captive exit
 if (
     GVAR(disableAIDodge)
-    || {isForcedWalk _unit}
     || {!(_unit checkAIFeature "MOVE")}
     || {!(_unit checkAIFeature "PATH")}
-    || {_unit getVariable ["ace_captives_isHandcuffed", false]}
-    || {_unit getVariable ["ace_captives_isSurrendering", false]}
-    || {_unit distance2D (_unit findNearestEnemy _unit) < (5 + random 15)}
-) exitWith {_stance};
+) exitWith {false};
 
 // callout
-if (RND(0.6)) then {
+if (RND(0.8)) then {
     [_unit, "Combat", "UnderFireE", 125] call FUNC(doCallout);
 };
 
@@ -57,22 +54,26 @@ private _suppression = _nearDistance && {getSuppression _unit > 0.1};
 private _relPos = [];
 private _anim = [];
 
+// drop stance
+if (_stance isEqualTo "STAND") then {_unit setUnitPosWeak "MIDDLE";};
+if (_stance isEqualTo "CROUCH" && { _nearDistance }) then {_unit setUnitPosWeak "DOWN";};
+
 // move left
-if (_dir < 250 && { RND(0.1) }) then {
-    _relPos = _unit getRelPos [DODGE_DISTANCE, -120];
-    _anim = ([["FastL", "FastLB"], ["TactL", "TactLB"]] select _suppression);
+if (RND(0.1) && { _dir < 80 }) then {
+    _relPos = _unit getRelPos [DODGE_DISTANCE, -60];
+    _anim = ([["FastL", "FastLF"], ["TactL", "TactLF"]] select _suppression);
 };
 
 // move right
-if (_dir > 80 && { RND(0.1) }) then {
-    _relPos = _unit getRelPos [DODGE_DISTANCE, 120];
-    _anim = ([["FastR", "FastRB"], ["TactR", "TactRB"]] select _suppression);
+if (RND(0.1) && { _dir > 250 }) then {
+    _relPos = _unit getRelPos [DODGE_DISTANCE, 60];
+    _anim = ([["FastR", "FastRF"], ["TactR", "TactRF"]] select _suppression);
 };
 
 // move back ~ more checks because sometimes we want the AI to move forward in CQB - nkenny
-if ((_dir < 320 || { _dir > 40 }) && { speed _unit < 2 } && { !_nearDistance }) then {
+if (_still  && { !_nearDistance } && {_dir > 320 || { _dir < 40 }}) then {
     _relPos = _unit getRelPos [DODGE_DISTANCE, 180];
-    _anim = (["FastB", "TactB"] select _suppression);
+    _anim = ([["FastB", "FastLB", "FastRB"], ["TactB", "TactLB","TactRB"]] select _suppression);
 };
 
 // check
@@ -81,20 +82,15 @@ if (_anim isEqualTo []) then {
     _anim = (["FastF", "TactF"] select _suppression);
 };
 
-// tweak dodge (in case unit is standing still!)
-_relPos set [2, (getPosATL _unit) select 2];
-if (((expectedDestination _unit) select 1) isEqualTo "DoNotPlan") then {_unit moveTo _relPos;};
+// tweak dodge
+_unit moveto _relPos;
+_unit setDestination [_relPos, "FORMATION PLANNED", true];
 
 // execute dodge
-_unit setDestination [_relPos, ["doNotPlanFormation", "FORMATION PLANNED"] select (_unit call FUNC(isIndoor)), true];
 [_unit, _anim, true] call FUNC(doGesture);
-
-// drop stance
-if (_stance isEqualTo "STAND") then {_unit setUnitPosWeak "MIDDLE";};
-if (_stance isEqualTo "CROUCH" && { _nearDistance }) then {_unit setUnitPosWeak "DOWN";};
 
 // watch distant shots
 if (!_nearDistance) then {_unit doWatch _pos;};
 
 // end
-_stance
+true

--- a/addons/main/functions/UnitAction/fnc_doHide.sqf
+++ b/addons/main/functions/UnitAction/fnc_doHide.sqf
@@ -24,7 +24,7 @@ if (
     stopped _unit
     || {!(_unit checkAIFeature "PATH")}
     || {!(_unit checkAIFeature "MOVE")}
-    || {currentCommand _unit in ["GET IN", "ACTION", "HEAL"]}
+    || {(currentCommand _unit) in ["GET IN", "ACTION", "HEAL"]}
 ) exitWith {false};
 
 // do nothing when already inside
@@ -42,8 +42,12 @@ if (_buildings isEqualTo []) then {
 _unit setVariable [QGVAR(currentTarget), _pos, GVAR(debug_functions)];
 _unit setVariable [QGVAR(currentTask), "Hide!", GVAR(debug_functions)];
 
+// stop
+doStop _unit;
+_unit forceSpeed 24;
+
 // Randomly scatter into buildings or hide!
-if ((_buildings isNotEqualTo []) && { RND(0.1) }) then {
+if (RND(0.1) && { _buildings isNotEqualTo [] }) then {
     _unit setVariable [QGVAR(currentTask), "Hide (inside)", GVAR(debug_functions)];
 
     // hide

--- a/tools/sqf_linter_LogChecker.py
+++ b/tools/sqf_linter_LogChecker.py
@@ -1,7 +1,7 @@
 import sys
 import os
 
-defaultFalsePositives = 18
+defaultFalsePositives = 16
 def main():
     f = open("sqf.log", "r")
     log = f.readlines()


### PR DESCRIPTION
### This pull request does three related things:
1. Improvements to the 'running in place'-bug     
2. Fixes movement changes brought on by _queue fix in #174           
3. Adds minor performance improvements to touched functions       

#### Changelog
Adds debug variable to tacticsHold

Improves stance change in brainAssess
Improves order of checks in isForced
Improves order of indoor checks in tacticsAssess
Improves performance and tweaks tactical response to long range combat
Improves doAssault performance by removing redundant checks

Fixes running in place issue in doDodge and improves exit conditions
Fixes doCover by forcing speed, increasing cover detection range and streamlining checks
Fixes doHide by forcing speed and re-implementing doStop. (which was necessary to keep AI in buildings)
Fixes redundant "can move" checks in brainAssess
Fixes 'indoor check' in brainAssess
Fixes suppression check in brainEngage  (without it, AI would fire excessively)
Fixes ACE forgetTarget fix by removing it. Works great with single units at 200 meters; not so much in any other paradigm.

Changed return value of doDodge to BOOLEAN.  Stance was used in previous iterations of FSM.
Changed retun value of doCover to BOOLEAN. 'unit' was never used.

### When merged this pull request will:
* Improve running in place bug
* Improve performance of three common functions (doDodge, doAssault, doCover)
* Improve AI's ability to avoid damage and take cover
