### PR TITLE
Fixes Garrisoned and Camped reinforcements

### DIFF
--- a/addons/danger/functions/fnc_tacticsReinforce.sqf
+++ b/addons/danger/functions/fnc_tacticsReinforce.sqf
@@ -22,8 +22,13 @@ params ["_unit", ["_target", []], ["_units", []], ["_delay", 300]];
 // exit on dead leader
 if (!(_unit call EFUNC(main,isAlive))) exitWith {false};
 
-// set new time
+// free garrisons
 private _group = group _unit;
+if (EGVAR(main,Loaded_WP) && {!(_unit checkAIFeature "PATH")}) then {
+    _group = [_group] call EFUNC(wp,taskReset);
+};
+
+// set new time
 _group setVariable [QGVAR(enableGroupReinforceTime), time + _delay, true];
 
 // set tasks

--- a/addons/danger/functions/fnc_tacticsReinforce.sqf
+++ b/addons/danger/functions/fnc_tacticsReinforce.sqf
@@ -29,6 +29,7 @@ if (EGVAR(main,Loaded_WP) && {!(_unit checkAIFeature "PATH")}) then {
 };
 
 // set new time
+_group setVariable [QGVAR(enableGroupReinforce), true, true];
 _group setVariable [QGVAR(enableGroupReinforceTime), time + _delay, true];
 
 // set tasks

--- a/addons/danger/functions/fnc_tacticsReinforce.sqf
+++ b/addons/danger/functions/fnc_tacticsReinforce.sqf
@@ -25,7 +25,7 @@ if (!(_unit call EFUNC(main,isAlive))) exitWith {false};
 // free garrisons
 private _group = group _unit;
 if (EGVAR(main,Loaded_WP) && {!(_unit checkAIFeature "PATH")}) then {
-    _group = [_group] call EFUNC(wp,taskReset);
+    _group = [_group, true] call EFUNC(wp,taskReset);
 };
 
 // set new time

--- a/addons/danger/stringtable.xml
+++ b/addons/danger/stringtable.xml
@@ -50,7 +50,7 @@
             <English>Enable Dynamic Reinforcement</English>
         </Key>
         <Key ID="STR_Lambs_Danger_Module_EnableGroupReinforce_SettingToolTip">
-            <English>Enable LAMBS dynamic reinforcement feature. This group will now move towards known enemy positions that are identified by the share information feature.</English>
+            <English>Enable LAMBS dynamic reinforcement feature. This group will now move towards known enemy positions that are identified by the share information feature.\nWARNING The reinforcement feature may override existing waypoints on groups responding to calls</English>
         </Key>
         <Key ID="STR_Lambs_Danger_Settings_MainCat">
             <English>Settings</English>

--- a/addons/danger/stringtable.xml
+++ b/addons/danger/stringtable.xml
@@ -50,7 +50,7 @@
             <English>Enable Dynamic Reinforcement</English>
         </Key>
         <Key ID="STR_Lambs_Danger_Module_EnableGroupReinforce_SettingToolTip">
-            <English>Enable LAMBS dynamic reinforcement feature. This group will now move towards known enemy positions that are identified by the share information feature.\nThis feature will not override garrison or other features which disable AI settings.</English>
+            <English>Enable LAMBS dynamic reinforcement feature. This group will now move towards known enemy positions that are identified by the share information feature.</English>
         </Key>
         <Key ID="STR_Lambs_Danger_Settings_MainCat">
             <English>Settings</English>

--- a/addons/main/script_macros.hpp
+++ b/addons/main/script_macros.hpp
@@ -18,7 +18,7 @@
     _unit \
 }
 
-#define DISABLE_COMPILE_CACHE
+// #define DISABLE_COMPILE_CACHE
 
 #ifdef DISABLE_COMPILE_CACHE
     #undef PREP

--- a/addons/main/script_macros.hpp
+++ b/addons/main/script_macros.hpp
@@ -18,7 +18,7 @@
     _unit \
 }
 
-// #define DISABLE_COMPILE_CACHE
+#define DISABLE_COMPILE_CACHE
 
 #ifdef DISABLE_COMPILE_CACHE
     #undef PREP

--- a/addons/wp/functions/fnc_taskReset.sqf
+++ b/addons/wp/functions/fnc_taskReset.sqf
@@ -33,6 +33,8 @@ private _units = units _group select {!isPlayer _x};
 [_group] call CBA_fnc_clearWaypoints;
 
 // remove LAMBS group variables
+_group setVariable [QEGVAR(danger,disableGroupAI), nil];
+_group setVariable [QEGVAR(danger,enableGroupReinforce), nil, true];
 _group setVariable [QGVAR(taskAssaultDestination), nil, true];
 _group setVariable [QGVAR(taskAssaultMembers), nil, true];
 
@@ -84,10 +86,6 @@ _groupNew setFormation (formation _group);
 
 // rejoin group
 _units joinSilent _groupNew;
-
-// reset lambs variable
-_groupNew setVariable [QEGVAR(danger,disableGroupAI), nil];
-_groupNew setVariable [QEGVAR(danger,enableGroupReinforce), _group getVariable [QEGVAR(danger,enableGroupReinforce), false], true];
 
 if (dynamicSimulationEnabled _group) then {
     [_groupNew, true] remoteExecCall ["enableDynamicSimulation", 2];

--- a/addons/wp/functions/fnc_taskReset.sqf
+++ b/addons/wp/functions/fnc_taskReset.sqf
@@ -32,9 +32,6 @@ private _units = units _group select {!isPlayer _x};
 // remove all current waypoints
 [_group] call CBA_fnc_clearWaypoints;
 
-// get group settings
-private _reinforce = _group getVariable [QEGVAR(danger,enableGroupReinforce), false];
-
 // remove LAMBS group variables
 _group setVariable [QGVAR(taskAssaultDestination), nil, true];
 _group setVariable [QGVAR(taskAssaultMembers), nil, true];

--- a/addons/wp/functions/fnc_taskReset.sqf
+++ b/addons/wp/functions/fnc_taskReset.sqf
@@ -6,6 +6,7 @@
  * Arguments:
  * 0: Group performing action, either unit <OBJECT> or group <GROUP>
  * 1: Soft reset where group variable name is not replaced <BOOL>
+ * 2: Reset waypoints in soft reset mode <BOOL>
  *
  * Return Value:
  * new group
@@ -19,7 +20,8 @@
 // init
 params [
     ["_group", grpNull, [grpNull, objNull]],
-    ["_softReset", false, [true]]
+    ["_softReset", false, [true]],
+    ["_resetWaypoints", false, [true]]
 ];
 
 // sort group
@@ -30,7 +32,7 @@ if (_group isEqualType objNull) then { _group = group _group; };
 private _units = units _group select {!isPlayer _x};
 
 // remove all current waypoints
-[_group] call CBA_fnc_clearWaypoints;
+if (_resetWaypoints) then {[_group] call CBA_fnc_clearWaypoints;};
 
 // remove LAMBS group variables
 _group setVariable [QEGVAR(danger,disableGroupAI), nil];

--- a/addons/wp/functions/fnc_taskReset.sqf
+++ b/addons/wp/functions/fnc_taskReset.sqf
@@ -7,7 +7,7 @@
  * 0: Group performing action, either unit <OBJECT> or group <GROUP>
  *
  * Return Value:
- * none
+ * new group
  *
  * Example:
  * [bob] call lambs_wp_fnc_taskReset;
@@ -34,6 +34,9 @@ _groupNew setFormation (formation _group);
 // remove all current waypoints
 [_group] call CBA_fnc_clearWaypoints;
 _group deleteGroupWhenEmpty true;
+
+// get group settings
+private _reinforce = _group getVariable [QEGVAR(danger,enableGroupReinforce), false];
 
 // remove LAMBS group variables
 _group setVariable [QGVAR(taskAssaultDestination), nil, true];
@@ -76,6 +79,7 @@ _group setVariable [QGVAR(taskAssaultMembers), nil, true];
 
 // reset lambs variable
 _groupNew setVariable [QEGVAR(danger,disableGroupAI), nil];
+_groupNew setVariable [QEGVAR(danger,enableGroupReinforce), _reinforce, true];
 
 if (dynamicSimulationEnabled _group) then {
     [_groupNew, true] remoteExecCall ["enableDynamicSimulation", 2];


### PR DESCRIPTION
### When merged this pull request will:
- Fixes garrisoned and camped units not being able to reinforce
- Fixes reinforcement variable in taskReset
- Updates stringtable to reflect feature

i.e., before this fix. Units set to waypoint Garrison or Camp were not able to reinforce when the 'Reinforcement' variable was enabled.
