### PR TITLE
Performance and optimalization

### DIFF
--- a/addons/danger/functions/fnc_brain.sqf
+++ b/addons/danger/functions/fnc_brain.sqf
@@ -77,6 +77,7 @@ _causeArray params ["_dangerCause", "_dangerPos", "", "_dangerCausedBy"]; // "_d
 // debug variable
 _unit setVariable [QEGVAR(main,FSMDangerCauseData), _causeArray, EGVAR(main,debug_functions)];
 
+// modify return
 _return pushBack _causeArray;
 
 // assess actions

--- a/addons/danger/functions/fnc_brain.sqf
+++ b/addons/danger/functions/fnc_brain.sqf
@@ -77,7 +77,7 @@ _causeArray params ["_dangerCause", "_dangerPos", "", "_dangerCausedBy"]; // "_d
 // debug variable
 _unit setVariable [QEGVAR(main,FSMDangerCauseData), _causeArray, EGVAR(main,debug_functions)];
 
-// modify return
+// add selected cause to return array
 _return pushBack _causeArray;
 
 // assess actions

--- a/addons/danger/functions/fnc_brain.sqf
+++ b/addons/danger/functions/fnc_brain.sqf
@@ -77,42 +77,49 @@ _causeArray params ["_dangerCause", "_dangerPos", "", "_dangerCausedBy"]; // "_d
 // debug variable
 _unit setVariable [QEGVAR(main,FSMDangerCauseData), _causeArray, EGVAR(main,debug_functions)];
 
+_return pushBack _causeArray;
+
+// assess actions
+if (_dangerCause isEqualTo DANGER_ASSESS) exitWith {
+    _return set [ACTION_ASSESS, true];
+    _return
+};
+
 // immediate actions
-if (_dangerCause in [DANGER_HIT, DANGER_BULLETCLOSE, DANGER_EXPLOSION, DANGER_FIRE]) then {
+if (_dangerCause in [DANGER_HIT, DANGER_BULLETCLOSE, DANGER_EXPLOSION, DANGER_FIRE]) exitWith {
     _return set [ACTION_IMMEDIATE, true];
+    _return
+};
+
+// engage actions
+if (_dangerCause in [DANGER_ENEMYDETECTED, DANGER_ENEMYNEAR, DANGER_CANFIRE]) exitWith {
+
+    // gesture + share information
+    if (_dangerCause isEqualTo DANGER_ENEMYNEAR && { (_group getVariable [QGVAR(contact), 0]) < time }) then {
+        [_unit, ["gestureFreeze", "gesturePoint"] select (_unit distance2D _dangerPos < 50)] call EFUNC(main,doGesture);
+        [_unit, ["Combat", "Stealth"] select (behaviour _unit isEqualTo "STEALTH"), "contact", 100] call EFUNC(main,doCallout);
+        [_unit, _dangerCausedBy, EGVAR(main,radioShout), true] call EFUNC(main,doShareInformation);
+    };
+
+    // return
+    _return set [ACTION_ENGAGE, (side _group) isNotEqualTo side (group _dangerCausedBy)];
+    _return set [ACTION_HIDE, _unit knowsAbout _dangerCausedBy < 0.1 && {(typeOf _dangerCausedBy) isNotEqualTo "SuppressTarget"}];    // hide if target unknown!
+    _return
 };
 
 // hide actions
 private _panic = RND(1 - GVAR(panicChance)) && {getSuppression _unit > 0.9};
-if (_dangerCause in [DANGER_DEADBODYGROUP, DANGER_DEADBODY] || {_panic}) then {
-    _return set [ACTION_HIDE, true];
+if (_panic || {_dangerCause in [DANGER_DEADBODYGROUP, DANGER_DEADBODY, DANGER_SCREAM]}) exitWith {
 
     // panic function
     if (_panic) then {
         [_unit] call EFUNC(main,doPanic);
     };
-};
 
-// engage actions   // should check all friendly sides?
-if (_dangerCause in [DANGER_ENEMYDETECTED, DANGER_ENEMYNEAR, DANGER_CANFIRE]) then {
-    _return set [ACTION_ENGAGE, (side _group) isNotEqualTo side (group _dangerCausedBy)];
-    _return set [ACTION_HIDE, _unit knowsAbout _dangerCausedBy < 0.1 && {(typeOf _dangerCausedBy) isNotEqualTo "SuppressTarget"}];    // hide if target unknown!
+    // return
+    _return set [ACTION_HIDE, true];
+    _return
 };
-
-// assess actions
-if (_dangerCause in [DANGER_ASSESS, DANGER_SCREAM]) then {
-    _return set [ACTION_ASSESS, true];
-};
-
-// gesture + share information
-if (RND(0.75) && { (_group getVariable [QGVAR(contact), 0]) < time }) then {
-    [_unit, ["gestureFreeze", "gesturePoint"] select (_unit distance2D _dangerPos < 50)] call EFUNC(main,doGesture);
-    [_unit, ["Combat", "Stealth"] select (behaviour _unit isEqualTo "STEALTH"), "contact", 100] call EFUNC(main,doCallout);
-    [_unit, _dangerCausedBy, EGVAR(main,radioShout), true] call EFUNC(main,doShareInformation);
-};
-
-// modify return
-_return pushBack _causeArray;
 
 // end
 _return

--- a/addons/danger/functions/fnc_brainAssess.sqf
+++ b/addons/danger/functions/fnc_brainAssess.sqf
@@ -23,7 +23,7 @@
     10 Assess
 */
 
-params ["_unit", ["_type", -1], ["_pos", [0, 0, 0]], ["_target", objNull]];
+params ["_unit", "", "", ["_target", objNull]];
 
 // timeout
 private _timeout = time + 2;

--- a/addons/danger/functions/fnc_brainAssess.sqf
+++ b/addons/danger/functions/fnc_brainAssess.sqf
@@ -20,7 +20,6 @@
 
 /*
     Assess actions
-    7 Scream
     10 Assess
 */
 
@@ -28,21 +27,6 @@ params ["_unit", ["_type", -1], ["_pos", [0, 0, 0]], ["_target", objNull]];
 
 // timeout
 private _timeout = time + 2;
-
-// check screams
-if (_type isEqualTo DANGER_SCREAM) exitWith {
-
-    // communicate danger!
-    [{_this call EFUNC(main,doShareInformation)}, [_unit, objNull, EGVAR(main,radioShout), true], 2 + random 3] call CBA_fnc_waitAndExecute;
-
-    // check danger
-    _unit doWatch _pos;
-    _unit setVariable [QEGVAR(main,currentTarget), _pos, EGVAR(main,debug_functions)];
-    _unit setVariable [QEGVAR(main,currentTask), "Heard scream!", EGVAR(main,debug_functions)];
-
-    // exit
-    _timeout - 1
-};
 
 // check if stopped
 if (!(_unit checkAIFeature "PATH")) exitWith {_timeout};
@@ -52,7 +36,7 @@ private _assignedTarget = assignedTarget _unit;
 if (
     !isNull _assignedTarget
     && {_unit distance2D _assignedTarget < GVAR(cqbRange)}
-    && {(typeOf _assignedTarget) isNotEqualTo "SuppressTarget"}
+    && {(_unit knowsAbout _assignedTarget) isNotEqualTo 0}
 ) exitWith {
     [_unit, _assignedTarget] call EFUNC(main,doAssault);
     _timeout + 2
@@ -70,7 +54,7 @@ if (_groupMemory isNotEqualTo []) exitWith {
 // stance
 private _stance = stance _unit;
 if (_stance isEqualTo "STAND") then {_unit setUnitPosWeak "MIDDLE";};
-if (_stance isEqualTo "CROUCH" && {getSuppression _unit > 0.9}) then {_unit setUnitPosWeak "DOWN";};
+if (getSuppression _unit > 0.9 && {_stance isEqualTo "CROUCH"}) then {_unit setUnitPosWeak "DOWN";};
 
 // building
 if (RND(EGVAR(main,indoorMove)) && {_unit call EFUNC(main,isIndoor)}) exitWith {

--- a/addons/danger/functions/fnc_brainEngage.sqf
+++ b/addons/danger/functions/fnc_brainEngage.sqf
@@ -27,7 +27,7 @@
 params ["_unit", ["_type", -1], ["_target", objNull]];
 
 // timeout
-private _timeout = time + 2;
+private _timeout = time + 3;
 
 // ACE3
 _unit setVariable ["ace_medical_ai_lastFired", CBA_missionTime];
@@ -35,6 +35,7 @@ _unit setVariable ["ace_medical_ai_lastFired", CBA_missionTime];
 // check
 if (
     isNull _target
+    || {_unit knowsAbout _target isEqualTo 0}
     || {(weapons _unit) isEqualTo []}
     || {needReload _unit > 0.85}
 ) exitWith {
@@ -58,14 +59,14 @@ if (
     && {_target call EFUNC(main,isAlive)}
 ) exitWith {
     [_unit, _target] call EFUNC(main,doAssault);
-    _timeout + random 1
+    _timeout + 2
 };
 
 // far, try to suppress
 if (
-    _type in [DANGER_ENEMYDETECTED, DANGER_CANFIRE]
-    && {_distance < 800}
+    _distance < 500
     && {RND(getSuppression _unit)}
+    && {_type in [DANGER_ENEMYDETECTED, DANGER_CANFIRE]}
 ) exitWith {
     _unit forceSpeed ([1, 2] select (_type isEqualTo DANGER_ENEMYDETECTED));
     [_unit, ATLtoASL ((_unit getHideFrom _target) vectorAdd [0, 0, random 1])] call EFUNC(main,doSuppress);

--- a/addons/danger/functions/fnc_brainHide.sqf
+++ b/addons/danger/functions/fnc_brainHide.sqf
@@ -21,6 +21,7 @@
     Hide actions
     5 DeadBodyGroup
     6 DeadBody
+    7 Hide
     - Panic
 */
 
@@ -28,6 +29,21 @@ params ["_unit", ["_type", -1], ["_pos", [0, 0, 0]]];
 
 // timeout
 private _timeout = time + 2;
+
+// check screams
+if (_type isEqualTo DANGER_SCREAM) exitWith {
+
+    // communicate danger!
+    [{_this call EFUNC(main,doShareInformation)}, [_unit, objNull, EGVAR(main,radioShout), true], 2 + random 3] call CBA_fnc_waitAndExecute;
+
+    // check danger
+    _unit lookAt _pos;
+    _unit setVariable [QEGVAR(main,currentTarget), _pos, EGVAR(main,debug_functions)];
+    _unit setVariable [QEGVAR(main,currentTask), "Heard scream!", EGVAR(main,debug_functions)];
+
+    // exit
+    _timeout - 1
+};
 
 // check if stopped
 if (!(_unit checkAIFeature "PATH")) exitWith {-1};
@@ -41,24 +57,20 @@ if (_type isEqualTo DANGER_DEADBODYGROUP) exitWith {
     // check body
     [_unit, _pos] call EFUNC(main,doCheckBody);
 
-    // pop smoke
-    if (!_indoor) then {[{_this call EFUNC(main,doSmoke)}, [_unit, _pos], random 2] call CBA_fnc_waitAndExecute;};
-
     // end
     _timeout + 3
 };
 
 // indoor units exit
-if (RND(0.05) && {_indoor}) exitWith {
-    //doStop _unit;   // test this more thoroughly!-- might make units too static! - nkenny
-    if (RND(EGVAR(main,indoorMove))) then {[_unit, _pos] call EFUNC(main,doReposition);};
+if (RND(0.05) && {_indoor} && {RND(EGVAR(main,indoorMove))}) exitWith {
+    [_unit, _pos] call EFUNC(main,doReposition);
     _timeout
 };
 
 // check bodies ~ enemy group!
-private _group = group _unit;
-private _groupMemory = _group getVariable [QEGVAR(main,groupMemory), []];
 if (_type isEqualTo DANGER_DEADBODY) exitWith {
+    private _group = group _unit;
+    private _groupMemory = _group getVariable [QEGVAR(main,groupMemory), []];
 
     // communicate danger!
     [{_this call EFUNC(main,doShareInformation)}, [_unit, objNull, EGVAR(main,radioShout), true], 2 + random 3] call CBA_fnc_waitAndExecute;

--- a/addons/danger/functions/fnc_brainReact.sqf
+++ b/addons/danger/functions/fnc_brainReact.sqf
@@ -28,7 +28,7 @@
 params ["_unit", ["_type", -1], ["_pos", [0, 0, 0]]];
 
 // timeout
-private _timeout = time + 1;
+private _timeout = time + 1.4;
 
 // ACE3
 _unit setVariable ["ace_medical_ai_lastHit", CBA_missionTime];
@@ -46,4 +46,4 @@ if (getSuppression _unit < 0.6 && {_type in [DANGER_EXPLOSION, DANGER_FIRE]}) ex
 [_unit, _pos] call EFUNC(main,doDodge);
 
 // end
-_timeout + 0.33
+_timeout

--- a/addons/danger/functions/fnc_tacticsAssess.sqf
+++ b/addons/danger/functions/fnc_tacticsAssess.sqf
@@ -20,12 +20,14 @@
 #define TACTICS_ASSAULT 3
 #define TACTICS_SUPPRESS 4
 #define TACTICS_ATTACK 5
+#define RANGE_MID 220
+#define RANGE_LONG 300
+#define RANGE_THREAT 450
 
 params [["_unit", objNull, [objNull]]];
 
 // check if group AI disabled
 private _group = group _unit;
-if (_group getVariable [QGVAR(disableGroupAI), false]) exitWith {false};
 
 // set variable
 _group setVariable [QGVAR(isExecutingTactic), true];
@@ -36,8 +38,8 @@ _unit setVariable [QEGVAR(main,currentTarget), objNull, EGVAR(main,debug_functio
 _unit setVariable [QEGVAR(main,currentTask), "Tactics Assess", EGVAR(main,debug_functions)];
 
 // gather data
-private _unitCount = count units _unit;     // how many soldiers the leader believes he is leading - nk
-private _enemies = (_unit targets [true, 1200]) select {_unit knowsAbout _x > 1};
+private _unitCount = count units _unit;
+private _enemies = (_unit targets [true, 800]) select {_unit knowsAbout _x > 1};
 private _plan = [];
 
 // leader assess EH
@@ -48,7 +50,7 @@ private _pos = [];
 if !(_enemies isEqualTo [] || {_unitCount < random 3}) then {
 
     // get modes
-    private _speedMode = speedMode _unit;
+    private _speedMode = (speedMode _unit) isEqualTo "FULL";
     private _combatMode = combatMode _unit;
     private _eyePos = eyePos _unit;
 
@@ -57,11 +59,11 @@ if !(_enemies isEqualTo [] || {_unitCount < random 3}) then {
 
     // vehicle response
     private _tankTarget = _enemies findIf {
-        (vehicle _x) isKindOf "Tank"
-        && {_unit distance2D _x < 450}
-        && {!(terrainIntersectASL [_eyePos, (eyePos _x) vectorAdd [0, 0, 5]])};
+        _unit distance2D _x < RANGE_THREAT
+        && {(vehicle _x) isKindOf "Tank"}
+        && {!(terrainIntersectASL [_eyePos, (eyePos _x) vectorAdd [0, 0, 5]])}
     };
-    if (_tankTarget != -1 && {!GVAR(disableAIHideFromTanksAndAircraft)} && {_speedMode isNotEqualTo "FULL"}) exitWith {
+    if (_tankTarget != -1 && {!GVAR(disableAIHideFromTanksAndAircraft)} && {!_speedMode}) exitWith {
         private _enemyVehicle = (_enemies select _tankTarget);
         _plan pushBack TACTICS_HIDE;
         _pos = _unit getHideFrom _enemyVehicle;
@@ -69,16 +71,16 @@ if !(_enemies isEqualTo [] || {_unitCount < random 3}) then {
         // anti-vehicle callout
         private _nameSoundConfig = configOf _enemyVehicle >> "nameSound";
         private _callout = if (isText _nameSoundConfig) then { getText _nameSoundConfig } else { "KeepFocused" };
-        [_unit, behaviour _unit, _callout, 125] call EFUNC(main,doCallout);
+        [_unit, behaviour _unit, _callout] call EFUNC(main,doCallout);
     };
 
     // anti-infantry tactics
-    _enemies = _enemies select {(vehicle _x) isKindOf "Man"};
+    _enemies = _enemies select {isNull objectParent _x};
 
     // Check for artillery ~ NB: support is far quicker now! and only targets infantry
     if (EGVAR(main,Loaded_WP) && {[side _unit] call EFUNC(WP,sideHasArtillery)}) then {
         private _artilleryTarget = _enemies findIf {
-            _unit distance2D _x > 200
+            _unit distance2D _x > RANGE_MID
             && {([_unit, getPos _x, 100] call EFUNC(main,findNearbyFriendlies)) isEqualTo []}
         };
         if (_artilleryTarget != -1) then {
@@ -97,7 +99,7 @@ if !(_enemies isEqualTo [] || {_unitCount < random 3}) then {
     // enemies within X meters of leader and either attacker or unit is inside buildings
     private _inside = _unit call EFUNC(main,isIndoor);
     private _nearIndoorTarget = _enemies findIf {
-        _unit distance2D _x < 25
+        _unit distance2D _x < (GVAR(cqbRange) * 1.4)
         && {_inside || {_x call EFUNC(main,isIndoor)}}
     };
     if (_nearIndoorTarget != -1) exitWith {
@@ -110,21 +112,21 @@ if !(_enemies isEqualTo [] || {_unitCount < random 3}) then {
 
     // enemies far away and above height and has LOS and limited knowledge!
     private _farHighertarget = _enemies findIf {
-        _unit distance2D _x > 300
+        !_speedMode
+        && {_unit distance2D _x > RANGE_LONG}
         && {_unit knowsAbout _x < 2}
         && {(getPosASL _x select 2 ) > ((getPosASL _unit select 2) + 15)}
-        && {!(terrainIntersectASL [_eyePos vectorAdd [0, 0, 5], eyePos _x])};
+        && {!(terrainIntersectASL [_eyePos vectorAdd [0, 0, 5], eyePos _x])}
     };
-    if (_farHighertarget != -1 && {_speedMode isNotEqualTo "FULL"}) exitWith {
+    if (_farHighertarget != -1) exitWith {
         _plan append [TACTICS_SUPPRESS, TACTICS_HIDE, TACTICS_HIDE];
         _pos = _unit getHideFrom (_enemies select _farHighertarget);
     };
 
-    // enemies near and away from buildings and below
+    // enemies near and below
     private _farNoCoverTarget = _enemies findIf {
-        _unit distance2D _x < 220
+        _unit distance2D _x < RANGE_MID
         && {((getPosASL _x) select 2) < ((getPosASL _unit select 2) - 15)}
-        && {([_x, GVAR(cqbRange) * 0.55] call EFUNC(main,findBuildings)) isEqualTo []}
     };
     if (_farNoCoverTarget != -1) exitWith {
         // trust in default attack routines!
@@ -132,20 +134,10 @@ if !(_enemies isEqualTo [] || {_unitCount < random 3}) then {
         _pos = _enemies select _farNoCoverTarget;
     };
 
-    // enemy at long range
-    private _farTarget = _enemies findIf {
-        _unit distance2D _x > 300
-    };
-    if (_farTarget != -1) then {
-        // suppress or flank
-        _plan append [TACTICS_SUPPRESS, TACTICS_FLANK];
-        if (_speedMode isEqualTo "FULL") exitWith {_plan pushBack TACTICS_ASSAULT;};
-        _pos = _unit getHideFrom (_enemies select _farTarget);
-    };
-
-    // enemy at inside buildings or fortified
+    // enemy at inside buildings or fortified or far
     private _fortifiedTarget = _enemies findIf {
-        _x call EFUNC(main,isIndoor)
+        _unit distance2D _x > RANGE_LONG
+        || {_x call EFUNC(main,isIndoor)}
         || {(nearestObjects [_x, ["Strategic", "StaticWeapon"], 2, true]) isNotEqualTo []}
     };
     if (_fortifiedTarget != -1) exitWith {
@@ -157,10 +149,11 @@ if !(_enemies isEqualTo [] || {_unitCount < random 3}) then {
         // combatmode
         if (_combatMode isEqualTo "RED") then {_plan pushBack TACTICS_ASSAULT;};
         if (_combatMode in ["YELLOW", "WHITE"]) then {_plan pushBack TACTICS_SUPPRESS;};
+        if (_speedMode) then {_plan pushBack TACTICS_ASSAULT;};
 
         // visibility / distance / no cover
         if !(terrainIntersectASL [_eyePos, eyePos (_enemies select _fortifiedTarget)]) then {_plan pushBack TACTICS_SUPPRESS;};
-        if (_unit distance2D _pos < 120) then {_plan pushBack TACTICS_ASSAULT;};
+        if (_unit distance2D _pos < RANGE_MID) then {_plan pushBack TACTICS_ASSAULT;};
         if ((nearestTerrainObjects [ _unit, ["BUSH", "TREE", "HOUSE", "HIDE"], 4, false, true ]) isEqualTo []) then {_plan pushBack TACTICS_FLANK;};
 
         // conceal movement
@@ -195,7 +188,7 @@ if (_plan isEqualTo [] || {_pos isEqualTo []}) exitWith {
 _unit setFormDir (_unit getDir _pos);
 
 // binoculars if appropriate!
-if (RND(0.2) && {(_unit distance2D _pos > 150) && {(binocular _unit) isNotEqualTo ""}}) then {
+if (RND(0.2) && {(_unit distance2D _pos > RANGE_MID) && {(binocular _unit) isNotEqualTo ""}}) then {
     _unit selectWeapon (binocular _unit);
     _unit doWatch _pos;
 };
@@ -220,7 +213,7 @@ switch (_plan) do {
     case TACTICS_ASSAULT: {
         // rush ~ assault
         [{_this call FUNC(tacticsAssault)}, [_unit, _pos], 22 + random 8] call CBA_fnc_waitAndExecute;
-        if !(_units isNotEqualTo []) then {[_units] call EFUNC(main,doSmoke);};
+        if (_units isNotEqualTo []) then {[_units] call EFUNC(main,doSmoke);};
     };
     case TACTICS_SUPPRESS: {
         // suppress

--- a/addons/danger/functions/fnc_tacticsContact.sqf
+++ b/addons/danger/functions/fnc_tacticsContact.sqf
@@ -16,7 +16,7 @@
  *
  * Public: No
 */
-params [["_unit", objNull, [objNull]], ["_enemy", objNull, [objNull]], ["_delay", 22]];
+params [["_unit", objNull, [objNull]], ["_enemy", objNull, [objNull]], ["_delay", 18]];
 
 // only leader
 if !((leader _unit) isEqualTo _unit || {_unit call EFUNC(main,isAlive)}) exitWith {false};
@@ -46,7 +46,6 @@ _group setVariable [QEGVAR(main,currentTactic), "Contact!", EGVAR(main,debug_fun
             _group setVariable [QGVAR(isExecutingTactic), nil];
             _group setVariable [QEGVAR(main,currentTactic), nil];
             _group enableAttack _enableAttack;
-            {_x setUnitPosWeak "AUTO"} foreach units _group;
             private _leader = leader _group;
             if (_leader call FUNC(isLeader)) then {
                 [_leader, _leader findNearestEnemy _leader] call FUNC(tactics);
@@ -54,7 +53,7 @@ _group setVariable [QEGVAR(main,currentTactic), "Contact!", EGVAR(main,debug_fun
         };
     },
     [_group, attackEnabled _group],
-    _delay + random 8
+    _delay + random 12
 ] call CBA_fnc_waitAndExecute;
 
 // change formation and attack state

--- a/addons/main/functions/UnitAction/fnc_doAssaultCQB.sqf
+++ b/addons/main/functions/UnitAction/fnc_doAssaultCQB.sqf
@@ -19,10 +19,9 @@ params ["_unit", ["_pos", [0, 0, 0]]];
 
 // check if stopped or busy
 if (
-    !(_unit call FUNC(isAlive))
+    currentCommand _unit in ["GET IN", "ACTION", "HEAL", "ATTACK"]
     || {!(_unit checkAIFeature "PATH")}
     || {!(_unit checkAIFeature "MOVE")}
-    || {currentCommand _unit in ["GET IN", "ACTION", "HEAL", "ATTACK"]}
 ) exitWith {false};
 
 // get buildings

--- a/addons/main/functions/UnitAction/fnc_doDodge.sqf
+++ b/addons/main/functions/UnitAction/fnc_doDodge.sqf
@@ -30,7 +30,7 @@ _unit setVariable [QGVAR(currentTask), "Dodge!", GVAR(debug_functions)];
 _unit setVariable [QGVAR(currentTarget), _pos, GVAR(debug_functions)];
 
 // prone override
-if (_still && {_stance isEqualTo "PRONE"} && {!(_unit call FUNC(isIndoor))}) exitWith {
+if (_still && {_stance isEqualTo "PRONE"} && {!(lineIntersects [eyePos _unit, (eyePos _unit) vectorAdd [0, 0, 7]])}) exitWith {
     [_unit, ["EvasiveLeft", "EvasiveRight"] select (_dir > 180), true] call FUNC(doGesture);
     _unit setDestination [[_unit getRelPos [DODGE_DISTANCE, -90], _unit getRelPos [DODGE_DISTANCE, 90]] select (_dir > 180), "FORMATION PLANNED", false];
     true

--- a/addons/main/functions/UnitAction/fnc_doFleeing.sqf
+++ b/addons/main/functions/UnitAction/fnc_doFleeing.sqf
@@ -21,11 +21,11 @@ params ["_unit"];
 
 // check disabled
 if (
-    _unit getVariable [QGVAR(disableAI), false]
+    _unit getVariable [QEGVAR(danger,disableAI), false]
     || {!(_unit checkAIFeature "PATH")}
     || {!(_unit checkAIFeature "MOVE")}
-    || {currentCommand _unit in ["GET IN", "ACTION", "REARM", "HEAL"]}
     || {GVAR(disableAIFleeing)}
+    || {currentCommand _unit in ["GET IN", "ACTION", "REARM", "HEAL"]}
 ) exitWith {false};
 
 // check for vehicle

--- a/addons/main/functions/UnitAction/fnc_doHide.sqf
+++ b/addons/main/functions/UnitAction/fnc_doHide.sqf
@@ -21,10 +21,9 @@ params ["_unit", "_pos", ["_range", 55], ["_buildings", []]];
 
 // stopped -- exit
 if (
-    stopped _unit
+    (currentCommand _unit) in ["GET IN", "ACTION", "HEAL"]
     || {!(_unit checkAIFeature "PATH")}
     || {!(_unit checkAIFeature "MOVE")}
-    || {(currentCommand _unit) in ["GET IN", "ACTION", "HEAL"]}
 ) exitWith {false};
 
 // do nothing when already inside


### PR DESCRIPTION
### This branch does the following:
1. Ruthlessly uses exitWith's in the core brain.sqf to save some cycles.
2. Simplifies tacticsAssess.sqf to streamline assessment phase
3. Simplifies and re-orders some function checks for speed.
4. Moves 'SCREAM' event to 'brainHide.sqf' where investigation and hiding actions should go. (improves performance of brainAssess.sqf which is checked more often!)

_Improvements_
Improves brain.sqf performance by using exitWith checks.
Improves brainEngage.sqf performance by tweaking timers and engagement ranges
Improves brainReact.sqf by simplifying timeout
Improves tacticsAssess.sqf by re-ordering checks and using more exitWiths
Improves tacticsContact.sqf timings and removes unneeded stance reset.
Improves doAssaultCQB.sqf exit conditions
Improves doFleeing.sqf exit conditions
Improves doHide.sqf exit conditions

_Fixes_
Fixes gesture/share information moved to correct state brain.sqf due to fix from #174
Fixes broken smoke throw under tactics_assault in tactics assessment.
Fixes broken wrong variable check in doFleeing.sqf

_Changes_
Changed 'scream'-event now handled by 'brainHide.sqf' instead of 'brainAssess.sqf'