### PR TITLE
Add custom share information handlers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,4 +10,5 @@ Feel free to add yourself to this when creating a pull request.
 ## CONTRIBUTORS
 - Couls
 - dedmen
+- mjc4wilton
 - R3voA3

--- a/addons/main/XEH_PREP.hpp
+++ b/addons/main/XEH_PREP.hpp
@@ -1,3 +1,4 @@
+PREP(addShareInformationHandler);
 PREP(doAnimation);
 PREP(doCallout);
 PREP(doGesture);

--- a/addons/main/XEH_preInit.sqf
+++ b/addons/main/XEH_preInit.sqf
@@ -7,4 +7,6 @@ GVAR(ChooseDialogSettingsCache) = false call CBA_fnc_createNamespace;
 // check for WP module
 GVAR(Loaded_WP) = isClass (configfile >> "CfgPatches" >> "lambs_wp");
 
+GVAR(shareHandlers) = [];
+
 ADDON = true;

--- a/addons/main/functions/fnc_addShareInformationHandler.sqf
+++ b/addons/main/functions/fnc_addShareInformationHandler.sqf
@@ -1,8 +1,8 @@
 /*
  * Author: mjc4wilton
  * Adds a custom handler to be called whenever the AI attempt to share information.
- * Code should return a BOOL where true allows information to be passed and false blocks it.
- * A single false will cause information to not be shared.
+ * Code should return a BOOL where false allows information to be passed and true blocks it.
+ * A single true will cause information to not be shared.
  *
  * Arguments:
  * 0: function <CODE>

--- a/addons/main/functions/fnc_addShareInformationHandler.sqf
+++ b/addons/main/functions/fnc_addShareInformationHandler.sqf
@@ -1,0 +1,27 @@
+/*
+ * Author: mjc4wilton
+ * Adds a custom handler to be called whenever the AI attempt to share information.
+ * Code should return a BOOL where true allows information to be passed and false blocks it.
+ * A single false will cause information to not be shared.
+ *
+ * Arguments:
+ * 0: function <CODE>
+ *
+ * Arguments passed to function:
+ * 0: unit sharing information <OBJECT>
+ * 1: enemy target <OBJECT>
+ * 2: range to share information, default 350 <NUMBER>
+ * 3: override radio ranges, default false <BOOLEAN>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [{false}] call lambs_main_fnc_addShareInformationHandler;
+ *
+ * Public: No
+*/
+
+params [["_code", {true}, [{}]]];
+
+GVAR(shareHandlers) pushBack _code;

--- a/addons/main/functions/fnc_addShareInformationHandler.sqf
+++ b/addons/main/functions/fnc_addShareInformationHandler.sqf
@@ -22,6 +22,6 @@
  * Public: No
 */
 
-params [["_code", {true}, [{}]]];
+params [["_code", {false}, [{}]]];
 
 GVAR(shareHandlers) pushBack _code;

--- a/addons/main/functions/fnc_doShareInformation.sqf
+++ b/addons/main/functions/fnc_doShareInformation.sqf
@@ -32,6 +32,14 @@ if (isNull _target) then {
     _target = _unit findNearestEnemy _unit;
 };
 
+// custom handlers
+private _handlersReturn = true;
+{
+    private _handlerResult = [_unit, _target, _range, _override] call _x;
+    if (_handlerResult isEqualTo false) exitWith {_handlersReturn = false};
+} forEach GVAR(shareHandlers);
+if (!_handlersReturn) exitWith {false};
+
 _unit setVariable [QGVAR(currentTarget), _target, GVAR(debug_functions)];
 //_unit setVariable [QGVAR(currentTask), "Share Information", GVAR(debug_functions)]; // do not update task -- sharing information is secondary info ~ nkenny
 

--- a/addons/main/functions/fnc_doShareInformation.sqf
+++ b/addons/main/functions/fnc_doShareInformation.sqf
@@ -36,7 +36,7 @@ if (isNull _target) then {
 private _handlersReturn = true;
 {
     private _handlerResult = [_unit, _target, _range, _override] call _x;
-    if (_handlerResult isEqualTo false) exitWith {_handlersReturn = false};
+    if (!isNil _handlerResult && _handlerResult isEqualTo false) exitWith {_handlersReturn = false};
 } forEach GVAR(shareHandlers);
 if (!_handlersReturn) exitWith {false};
 

--- a/addons/main/functions/fnc_doShareInformation.sqf
+++ b/addons/main/functions/fnc_doShareInformation.sqf
@@ -33,12 +33,12 @@ if (isNull _target) then {
 };
 
 // custom handlers
-private _handlersReturn = true;
+private _stopShare = false;
 {
-    private _handlerResult = [_unit, _target, _range, _override] call _x;
-    if (!isNil _handlerResult && _handlerResult isEqualTo false) exitWith {_handlersReturn = false};
+    private _callbackResult = [_unit, _target, _range, _override] call _x;
+    if (!(isNil "_callbackResult") && {_callbackResult isEqualTo true}) exitWith {_stopShare = true};
 } forEach GVAR(shareHandlers);
-if (!_handlersReturn) exitWith {false};
+if (_stopShare) exitWith {false};
 
 _unit setVariable [QGVAR(currentTarget), _target, GVAR(debug_functions)];
 //_unit setVariable [QGVAR(currentTask), "Share Information", GVAR(debug_functions)]; // do not update task -- sharing information is secondary info ~ nkenny


### PR DESCRIPTION
### When merged this pull request will:

1. Add `lambs_main_fnc_addShareInformationHandler` which allows for custom functions to block information sharing (similar to how `ace_explosives_fnc_addDetonateHandler` [works](https://ace3mod.com/wiki/framework/explosives-framework.html#53-detonation-handler)).
2. Add myself to contributor list.
