### PR TITLE
Improve AI Artillery -- disembarking and improving doArtillery

### DIFF
--- a/addons/danger/functions/fnc_brainVehicle.sqf
+++ b/addons/danger/functions/fnc_brainVehicle.sqf
@@ -57,6 +57,12 @@ private _attack = _cause in [DANGER_ENEMYDETECTED, DANGER_ENEMYNEAR, DANGER_HIT,
 private _artillery = _vehicle getVariable [QEGVAR(main,isArtillery), getNumber (configOf _vehicle >> "artilleryScanner") > 0];
 if (_artillery) exitWith {
     _vehicle setVariable [QEGVAR(main,isArtillery), true];
+
+    // enemies within 12-30m may cause crew to disembark!
+    if (_attack && {_dangerCausedBy distanceSqr _vehicle < (144 + random 324)} && {currentCommand _unit isEqualTo ""}) then {
+        (units _unit) orderGetIn false;
+        _unit setSuppression 0.94; // to prevent instant laser aim on exiting vehicle
+    };
     [_timeout] + _causeArray
 };
 
@@ -69,7 +75,7 @@ if (_static) exitWith {
 
     // get out if enemy near
     if ((_unit findNearestEnemy _dangerPos) distance _vehicle < (6 + random 15)) then {
-        [_unit] orderGetIn false;
+        (units _unit) orderGetIn false;
         _unit setSuppression 0.94; // to prevent instant laser aim on exiting vehicle
     };
 

--- a/addons/wp/functions/fnc_doArtillery.sqf
+++ b/addons/wp/functions/fnc_doArtillery.sqf
@@ -72,7 +72,7 @@ if (canFire _gun && {_caller call EFUNC(main,isAlive)}) then {
 
     if !(_skipCheckrounds) then {
         // check rounds
-        for "_check" from 1 to (1 + random 2) do {
+        for "_check" from 1 to (round (1 + random 1)) do {
 
             // randomize target location
             private _target = _center getPos [(100 + (random _accuracy * 2)) / _check, _direction + 45 - random 90];
@@ -83,7 +83,10 @@ if (canFire _gun && {_caller call EFUNC(main,isAlive)}) then {
             if (_target inRangeOfArtillery [[_gun], _ammo]) then {
 
                 // check rounds barrage
-                _gun commandArtilleryFire [_target, _ammo, 1 + random 2];
+                for "_i" from 1 to (round (1 + random 1)) do {
+                    _gun commandArtilleryFire [_target, _ammo, 1];
+                    waitUntil {unitReady _gun};
+                };
 
                 // debug
                 if (EGVAR(main,debug_functions)) then {

--- a/addons/wp/functions/fnc_doArtillery.sqf
+++ b/addons/wp/functions/fnc_doArtillery.sqf
@@ -151,7 +151,7 @@ if (canFire _gun && {_caller call EFUNC(main,isAlive)}) then {
 if (_markerList isNotEqualTo []) then {
     [
         {
-            {deleteMarker _x; true} count _this
+            {deleteMarker _x;} forEach _this;
         }, _markerList, 60
     ] call CBA_fnc_waitAndExecute;
 };

--- a/addons/wp/functions/fnc_doArtillery.sqf
+++ b/addons/wp/functions/fnc_doArtillery.sqf
@@ -9,6 +9,7 @@
  * 2: Caller of strike <OBJECT>
  * 3: Rounds fired, default 3 - 7 <NUMBER>
  * 4: Dispersion accuracy, default 100 <NUMBER>
+ * 5: Skip check rounds and skip shooting delay, default false <BOOL>
  *
  * Return Value:
  * none
@@ -32,15 +33,15 @@ if (isNull _caller) then {
 
 [QEGVAR(danger,OnArtilleryCalled), [_caller, group _caller, _gun, _pos]] call EFUNC(main,eventCallback);
 
-// Gun and caller must be alive
+// gun and caller must be alive
 if !(canFire _gun && {(_caller call EFUNC(main,isAlive))}) exitWith {false};
 
 // settings
 private _direction = _gun getDir _pos;
-private _center = _pos getPos [(_accuracy / 3) * -1, _direction];
+private _center = _pos getPos [_accuracy * 0.33, -_direction];
 private _offset = 0;
 
-// higher class artillery fire more rounds? Less accurate?
+// heavier artillery fires more rounds, more accurately
 if !((vehicle _gun) isKindOf "StaticMortar") then {
     _rounds = _rounds * 2;
     _accuracy = _accuracy * 0.5;
@@ -49,47 +50,50 @@ if !((vehicle _gun) isKindOf "StaticMortar") then {
 private _ammo = (getArtilleryAmmo [_gun]) param [0, ""];
 private _time = _gun getArtilleryETA [_center, _ammo];
 
-// delay
-private _mainStrike = linearConversion [100, 2000, (_gun distance2D _pos), 30, 90, true];
-private _checkRounds = (_time + random 35);
+// delay ~ no delay if skipping checkRounds nkenny
+private _mainStrike = [linearConversion [100, 2000, (_gun distance2D _pos), 30, 90, true], 0] select _skipCheckrounds;
+private _checkRounds = _time + random 35;
 
-// delay
+// delay for main strike
 sleep _mainStrike;
 
-// initate attack (gun and caller must be alive)
+// debug marker list
+private _markerList = [];
+
+// initate attack ~ gun and caller must be alive
 if (canFire _gun && {_caller call EFUNC(main,isAlive)}) then {
 
-    // debug marker list
-    private _mlist = [];
+    // caller marker
+    if (EGVAR(main,debug_functions)) then {
+        private _markerCaller = [_caller, ["Spotter (%1M)", round (_caller distance2D _center)], "Color5_FD_F", "mil_arrow"] call EFUNC(main,dotMarker);
+        _markerCaller setMarkerDir (_caller getDir _center);
+        _markerList pushBack _markerCaller;
+    };
 
     if !(_skipCheckrounds) then {
         // check rounds
         for "_check" from 1 to (1 + random 2) do {
 
-            // check rounds barrage
-            for "_i" from 1 to (1 + random 1) do {
+            // randomize target location
+            private _target = _center getPos [(100 + (random _accuracy * 2)) / _check, _direction + 45 - random 90];
 
-                // Randomize target location
-                private _target = _center getPos [(100 + (random _accuracy * 2)) / _check, _direction + 50 - random 100];
+            private _ammo = (getArtilleryAmmo [_gun]) param [0, ""];
+            if (_ammo isEqualTo "") exitWith {};
 
-                private _ammo = (getArtilleryAmmo [_gun]) param [0, ""];
-                if (_ammo isEqualTo "") exitWith {};
+            if (_target inRangeOfArtillery [[_gun], _ammo]) then {
 
-                if (_target inRangeOfArtillery [[_gun], _ammo]) then {
-                    // Fire round
-                    _gun commandArtilleryFire [_target, _ammo, 1];
+                // check rounds barrage
+                _gun commandArtilleryFire [_target, _ammo, 1 + random 2];
 
-                    // debug
-                    if (EGVAR(main,debug_functions)) then {
-                        private _m = [_target, ["%1 %3 (check round %2)", getText (configOf _gun >> "displayName"), _i, groupID (group _gun)], "Color4_FD_F", "hd_destroy"] call EFUNC(main,dotMarker);
-                        _mlist pushBack _m;
-                    };
-                    // waituntil
-                    waitUntil {unitReady _gun};
-                } else {
-                    if (EGVAR(main,debug_functions)) then {
-                        ["Error Target position is not reachable with artillery"] call EFUNC(main,debugLog);
-                    };
+                // debug
+                if (EGVAR(main,debug_functions)) then {
+                    private _marker = [_target, ["%1 %2 (check round barrage %3)", getText (configOf _gun >> "displayName"), groupID (group _gun), _check], "Color4_FD_F", "mil_destroy"] call EFUNC(main,dotMarker);
+                    _markerList pushBack _marker;
+                };
+
+            } else {
+                if (EGVAR(main,debug_functions)) then {
+                    ["Error Target position is not reachable with artillery"] call EFUNC(main,debugLog);
                 };
             };
 
@@ -99,27 +103,33 @@ if (canFire _gun && {_caller call EFUNC(main,isAlive)}) then {
     };
 
     // step for main barrage
-    if !(canFire _gun && {_caller call EFUNC(main,isAlive)}) exitWith {false};
+    if !(canFire _gun && {_caller call EFUNC(main,isAlive)}) exitWith {};
 
-    // Main Barrage
+    // caller marker
+    if (EGVAR(main,debug_functions)) then {
+        (_markerList select 0) setMarkerPos (getPos _caller);
+        (_markerList select 0) setMarkerDir (_caller getDir _center);
+    };
+
+    // main barrage
     for "_i" from 1 to _rounds do {
 
-        // Randomize target location
-        private _target = _center getPos [_offset + random _accuracy, _direction + 50 - random 100];
-        _offset = _offset + _accuracy / 3;
+        // randomize target location
+        private _target = _center getPos [_offset + random _accuracy, _direction + 45 - random 90];
+        _offset = _offset + (_accuracy * 0.33);
 
         private _ammo = (getArtilleryAmmo [_gun]) param [0, ""];
         if (_ammo isEqualTo "") exitWith {};
 
         if (_target inRangeOfArtillery [[_gun], _ammo]) then {
 
-            // Fire round
+            // fire round
             _gun commandArtilleryFire [_target, _ammo, 1];
 
             // debug
             if (EGVAR(main,debug_functions)) then {
-                private _m = [_target, ["%1 %3 (main salvo %2)", getText (configOf _gun >> "displayName"), _i, groupID (group _gun)], "colorIndependent", "hd_destroy"] call EFUNC(main,dotMarker);
-                _mlist pushBack _m;
+                private _marker = [_target, ["%1 %2 (main salvo %3)", getText (configOf _gun >> "displayName"), groupID (group _gun), _i], "Color5_FD_F", "mil_destroy"] call EFUNC(main,dotMarker);
+                _markerList pushBack _marker;
             };
 
             // waituntil
@@ -135,15 +145,15 @@ if (canFire _gun && {_caller call EFUNC(main,isAlive)}) then {
     if (EGVAR(main,debug_functions)) then {
         ["%1 Artillery strike complete: %2 fired %3 shots at %4m", side _gun, getText (configOf _gun >> "displayName"), _rounds, round (_gun distance2D _pos)] call EFUNC(main,debugLog);
     };
+};
 
-    // clean markers!
-    if (_mlist isNotEqualTo []) then {
-        [
-            {
-                {deleteMarker _x; true} count _this
-            }, _mList, 60
-        ] call CBA_fnc_waitAndExecute;
-    };
+// clean markers!
+if (_markerList isNotEqualTo []) then {
+    [
+        {
+            {deleteMarker _x; true} count _this
+        }, _markerList, 60
+    ] call CBA_fnc_waitAndExecute;
 };
 
 // delay

--- a/addons/wp/functions/fnc_taskArtillery.sqf
+++ b/addons/wp/functions/fnc_taskArtillery.sqf
@@ -15,7 +15,7 @@
  * none
  *
  * Example:
- * [side bob, getPos angryJoe, bob] spawn lambs_wp_fnc_taskArtillery;
+ * [side bob, getPos angryJoe, bob] call lambs_wp_fnc_taskArtillery;
  *
  * Public: Yes
 */


### PR DESCRIPTION
### When merged this pull request will:
Adds artillery crew will disembark when threatened by near enemies
Adds skipCheckRounds will also skip main strike delay*
Adds debug marker for spotter
Fixes check round barrages nearly always be one round
Fixes debug markers were occasionally not removed when caller died
Changes artillery debug markers uses a colour not used by a faction
Changes: static weapon crew will disembark when threatened (instead of only effective commander)
Minor header and variable name clean ups

*This is done according to earlier discussion and the actual description given in stringtables! 