### PR TITLE
Fix armored vehicles suppressing useless positions

### DIFF
--- a/addons/main/functions/VehicleAction/fnc_doVehicleAssault.sqf
+++ b/addons/main/functions/VehicleAction/fnc_doVehicleAssault.sqf
@@ -30,9 +30,9 @@ if (
     || {terrainIntersectASL [eyePos _vehicle, eyePos _target]}
 ) exitWith {false};
 
-// get target position
+// get target position ~ exit if target is unknown  -nkenny
 private _predictedPos = _unit getHideFrom _target;
-if (_predictedPos isEqualTo [0, 0, 0]) then {_predictedPos = _pos;};
+if (_predictedPos isEqualTo [0, 0, 0]) exitWith {false};
 
 // define buildings
 private _visibility = [objNull, "VIEW", _vehicle] checkVisibility [eyePos _vehicle, ATLtoASL (_predictedPos vectorAdd [0, 0, 1 + random 1])];


### PR DESCRIPTION
### FIX ARMORED VEHICLES
Fixes armored vehicles suppressing  useless positions

Ref bug: https://github.com/nk3nny/LambsDanger/issues/220

### DESCRIPTION OF BUG
Armoured vehicles would occasionally fire random bursts into the air.  The reason for this was that the unit would be put into combat mode, without having knowledge about a targets actual location. If that target was also situated away from buildings. The Armored vehicle would shoot at the "_dangerPos"  which is rarely a useful thing ;) 

### SIDE BENEFITS
Should also prevent reinforcing armoured vehicles from stopping at odd places when reacting to shared information. 