### PR TITLE
Fix brain engage suppression bug and add minor tweaks

### DIFF
--- a/addons/danger/functions/fnc_brainEngage.sqf
+++ b/addons/danger/functions/fnc_brainEngage.sqf
@@ -37,7 +37,7 @@ if (
     isNull _target
     || {_unit knowsAbout _target isEqualTo 0}
     || {(weapons _unit) isEqualTo []}
-    || {needReload _unit > 0.85}
+    || {needReload _unit > 0.8}
 ) exitWith {
     _timeout
 };
@@ -61,14 +61,16 @@ if (
     _timeout + 4
 };
 
+// set speed
+_unit forceSpeed ([-1, 1] select (_type isEqualTo DANGER_CANFIRE));
+
 // far, try to suppress
 if (
     _distance < 500
     && {RND(getSuppression _unit)}
     && {_type in [DANGER_ENEMYDETECTED, DANGER_CANFIRE]}
 ) exitWith {
-    _unit forceSpeed ([1, 2] select (_type isEqualTo DANGER_ENEMYDETECTED));
-    [_unit, ATLtoASL (_unit getHideFrom _target)] call EFUNC(main,doSuppress);
+    [_unit, ATLtoASL ((_unit getHideFrom _target) vectorAdd [0, 0, 0.5])] call EFUNC(main,doSuppress);
     _timeout + 4
 };
 


### PR DESCRIPTION
### This PR does three things: 
1. Re-implements a slight offset to suppression.  This fixes an error that crops up: units were "yelling" negative because their doSuppress commands failed. 
2. Includes a better handling of speed changes.  This fixes an issue were (particularly) player led groups become very intractable with LAMBS Danger
3. Changes ammunition exit clause to exit at higher round counts.  This will generally prevent AI from assaulting with no ammunition -- and in fact also slows down doSuppression and doAssault  calls.  

Default changed from 30 * 0.15 rounds ~ 4.5 rounds in a 30 round magazine
Will now exit on 30 * 0.2 rounds ~ 6 rounds in a 30 round magazine 

_Changelog_
Fixed units yelling 'Negative' for suppression
Improved handling of speed change when engaging 
Improved exit clause by better balanced ammunition check

