### PR TITLE
Remove assault stance changes

### DIFF
--- a/addons/main/functions/UnitAction/fnc_doAssault.sqf
+++ b/addons/main/functions/UnitAction/fnc_doAssault.sqf
@@ -54,7 +54,7 @@ private _pos = if (_buildings isEqualTo []) then {
 };
 
 // stance and speed
-_unit setUnitPosWeak selectRandom ["UP", "UP", "MIDDLE"];
+//_unit setUnitPosWeak selectRandom ["UP", "UP", "MIDDLE"];
 [_unit, _pos] call FUNC(doAssaultSpeed);
 
 // execute

--- a/addons/main/functions/UnitAction/fnc_doAssault.sqf
+++ b/addons/main/functions/UnitAction/fnc_doAssault.sqf
@@ -54,7 +54,7 @@ private _pos = if (_buildings isEqualTo []) then {
 };
 
 // stance and speed
-//_unit setUnitPosWeak selectRandom ["UP", "UP", "MIDDLE"];
+//_unit setUnitPosWeak selectRandom ["UP", "UP", "MIDDLE"];     // TODO : remove lines if no problems are reported within one week of 22.04.21 - nkenny
 [_unit, _pos] call FUNC(doAssaultSpeed);
 
 // execute

--- a/addons/main/functions/UnitAction/fnc_doAssaultMemory.sqf
+++ b/addons/main/functions/UnitAction/fnc_doAssaultMemory.sqf
@@ -55,7 +55,7 @@ if (_distance2D < 12) then {_unit setVariable ["ace_medical_ai_lastFired", CBA_m
 // CQB or suppress
 if (RND(0.9) || {_distance2D < 66}) then {
     // movement
-    _unit setUnitPosWeak (["MIDDLE", "UP"] select (_distance2D > 5));
+    //_unit setUnitPosWeak (["MIDDLE", "UP"] select (_distance2D > 5));
     _unit forceSpeed 4;
 
     // execute CQB move

--- a/addons/main/functions/UnitAction/fnc_doAssaultMemory.sqf
+++ b/addons/main/functions/UnitAction/fnc_doAssaultMemory.sqf
@@ -55,7 +55,7 @@ if (_distance2D < 12) then {_unit setVariable ["ace_medical_ai_lastFired", CBA_m
 // CQB or suppress
 if (RND(0.9) || {_distance2D < 66}) then {
     // movement
-    //_unit setUnitPosWeak (["MIDDLE", "UP"] select (_distance2D > 5));
+    //_unit setUnitPosWeak (["MIDDLE", "UP"] select (_distance2D > 5));      // TODO : remove lines if no problems are reported within one week of 22.04.21 - nkenny
     _unit forceSpeed 4;
 
     // execute CQB move


### PR DESCRIPTION
### When merged this pull request will:
Uncomments stance changes on aggressive (assault) actions.  This reduces the 'enforced' stance changes considerably.  The tweaks works positively by keeping the majority of stance changes on group or defensive actions.  I believe this works with better synergy with our new formations/pathfinding module. 

Fixes units standing up at inopportune times. 

I would like to test this publicly in the SW 2.5.1 'RC'. The features can be easily re-implemented if players experience AI trying to crawl inside buildings in CQB.  In my own testing. That has not tended to occur. 