### PR TITLE
Refines Suppression in brainEngage and tacticsAssess

### DIFF
--- a/addons/danger/functions/fnc_brainEngage.sqf
+++ b/addons/danger/functions/fnc_brainEngage.sqf
@@ -37,13 +37,13 @@ if (
     isNull _target
     || {_unit knowsAbout _target isEqualTo 0}
     || {(weapons _unit) isEqualTo []}
-    || {needReload _unit > 0.8}
+    || {combatMode _unit in ["BLUE", "GREEN"]}
 ) exitWith {
     _timeout
 };
 
-// look at_this
-if (_unit knowsAbout _target > 3.9) then {
+// look at target
+if ((_unit knowsAbout _target) isEqualTo 4) then {
     _unit lookAt _target;
 };
 
@@ -68,7 +68,7 @@ _unit forceSpeed ([-1, 1] select (_type isEqualTo DANGER_CANFIRE));
 if (
     _distance < 500
     && {RND(getSuppression _unit)}
-    && {_type in [DANGER_ENEMYDETECTED, DANGER_CANFIRE]}
+    && {_type isEqualTo DANGER_CANFIRE || {RND(0.5) || {_type isEqualTo DANGER_ENEMYDETECTED}}}
 ) exitWith {
     [_unit, ATLtoASL ((_unit getHideFrom _target) vectorAdd [0, 0, 0.5])] call EFUNC(main,doSuppress);
     _timeout + 4

--- a/addons/danger/functions/fnc_brainEngage.sqf
+++ b/addons/danger/functions/fnc_brainEngage.sqf
@@ -68,7 +68,7 @@ _unit forceSpeed ([-1, 1] select (_type isEqualTo DANGER_CANFIRE));
 if (
     _distance < 500
     && {RND(getSuppression _unit)}
-    && {_type isEqualTo DANGER_CANFIRE || {RND(0.5) || {_type isEqualTo DANGER_ENEMYDETECTED}}}
+    && {_type isEqualTo DANGER_CANFIRE || {RND(0.5) && {_type isEqualTo DANGER_ENEMYDETECTED}}}
 ) exitWith {
     [_unit, ATLtoASL ((_unit getHideFrom _target) vectorAdd [0, 0, 0.5])] call EFUNC(main,doSuppress);
     _timeout + 4

--- a/addons/danger/functions/fnc_brainEngage.sqf
+++ b/addons/danger/functions/fnc_brainEngage.sqf
@@ -37,7 +37,7 @@ if (
     isNull _target
     || {_unit knowsAbout _target isEqualTo 0}
     || {(weapons _unit) isEqualTo []}
-    || {combatMode _unit in ["BLUE", "GREEN"]}
+    || {(combatMode _unit) in ["BLUE", "GREEN"]}
 ) exitWith {
     _timeout
 };

--- a/addons/danger/functions/fnc_tacticsAssess.sqf
+++ b/addons/danger/functions/fnc_tacticsAssess.sqf
@@ -20,6 +20,7 @@
 #define TACTICS_ASSAULT 3
 #define TACTICS_SUPPRESS 4
 #define TACTICS_ATTACK 5
+#define RANGE_NEAR 120
 #define RANGE_MID 220
 #define RANGE_LONG 300
 #define RANGE_THREAT 450
@@ -38,7 +39,7 @@ _unit setVariable [QEGVAR(main,currentTarget), objNull, EGVAR(main,debug_functio
 _unit setVariable [QEGVAR(main,currentTask), "Tactics Assess", EGVAR(main,debug_functions)];
 
 // get max data range ~ reduced for forests or cities - nkenny
-private _pos = getPos _unit;
+private _pos = getPosATL _unit;
 private _range = (850 * (1 - (_pos getEnvSoundController "houses") - (_pos getEnvSoundController "trees") - (_pos getEnvSoundController "forest") * 0.5)) max 120;
 
 // gather data
@@ -84,7 +85,7 @@ if !(_enemies isEqualTo [] || {_unitCount < random 3}) then {
     if (EGVAR(main,Loaded_WP) && {[side _unit] call EFUNC(WP,sideHasArtillery)}) then {
         private _artilleryTarget = _enemies findIf {
             _unit distance2D _x > RANGE_MID
-            && {([_unit, getPos _x, 100] call EFUNC(main,findNearbyFriendlies)) isEqualTo []}
+            && {([_unit, getPos _x, RANGE_NEAR] call EFUNC(main,findNearbyFriendlies)) isEqualTo []}
         };
         if (_artilleryTarget != -1) then {
             [_unit, _unit getHideFrom (_enemies select _artilleryTarget)] call EFUNC(main,doCallArtillery);   // possibly add delay? ~ nkenny
@@ -102,7 +103,7 @@ if !(_enemies isEqualTo [] || {_unitCount < random 3}) then {
     // enemies within X meters of leader and either attacker or unit is inside buildings
     private _inside = _unit call EFUNC(main,isIndoor);
     private _nearIndoorTarget = _enemies findIf {
-        _unit distance2D _x < (GVAR(cqbRange) * 1.4)
+        _unit distance2D _x < RANGE_NEAR
         && {_inside || {_x call EFUNC(main,isIndoor)}}
     };
     if (_nearIndoorTarget != -1) exitWith {
@@ -118,7 +119,7 @@ if !(_enemies isEqualTo [] || {_unitCount < random 3}) then {
         !_speedMode
         && {_unit distance2D _x > RANGE_LONG}
         && {_unit knowsAbout _x < 2}
-        && {((getPosASL _x) select 2) > ((_eyePos select 2) + 15)}
+        && {((getPosWorld _x) select 2) > ((_eyePos select 2) + 15)}
         && {!(terrainIntersectASL [_eyePos vectorAdd [0, 0, 5], eyePos _x])}
     };
     if (_farHighertarget != -1) exitWith {
@@ -129,7 +130,7 @@ if !(_enemies isEqualTo [] || {_unitCount < random 3}) then {
     // enemies near and below
     private _farNoCoverTarget = _enemies findIf {
         _unit distance2D _x < RANGE_MID
-        && {((getPosASL _x) select 2) < ((_eyePos select 2) - 15)}
+        && {((getPosWorld _x) select 2) < ((_eyePos select 2) - 15)}
     };
     if (_farNoCoverTarget != -1) exitWith {
         // trust in default attack routines!
@@ -152,7 +153,7 @@ if !(_enemies isEqualTo [] || {_unitCount < random 3}) then {
         // combatmode
         private _combatMode = combatMode _unit;
         if (_combatMode isEqualTo "RED") then {_plan pushBack TACTICS_ASSAULT;};
-        if (_combatMode in ["YELLOW", "WHITE"]) then {_plan pushBack TACTICS_SUPPRESS;};
+        if (_combatMode isEqualTo "YELLOW") then {_plan pushBack TACTICS_SUPPRESS;};
         if (_speedMode) then {_plan pushBack TACTICS_ASSAULT;};
 
         // visibility / distance / no cover

--- a/addons/danger/functions/fnc_tacticsAssess.sqf
+++ b/addons/danger/functions/fnc_tacticsAssess.sqf
@@ -119,7 +119,7 @@ if !(_enemies isEqualTo [] || {_unitCount < random 3}) then {
         !_speedMode
         && {_unit distance2D _x > RANGE_LONG}
         && {_unit knowsAbout _x < 2}
-        && {((getPosWorld _x) select 2) > ((_eyePos select 2) + 15)}
+        && {((getPosASL _x) select 2) > ((_eyePos select 2) + 15)}
         && {!(terrainIntersectASL [_eyePos vectorAdd [0, 0, 5], eyePos _x])}
     };
     if (_farHighertarget != -1) exitWith {
@@ -130,7 +130,7 @@ if !(_enemies isEqualTo [] || {_unitCount < random 3}) then {
     // enemies near and below
     private _farNoCoverTarget = _enemies findIf {
         _unit distance2D _x < RANGE_MID
-        && {((getPosWorld _x) select 2) < ((_eyePos select 2) - 15)}
+        && {((getPosASL _x) select 2) < ((_eyePos select 2) - 15)}
     };
     if (_farNoCoverTarget != -1) exitWith {
         // trust in default attack routines!


### PR DESCRIPTION
**Refines individual suppression and engagement in three ways:**
1. Makes it possible to quit engagement cycle by setting combatMode to "BLUE" or "GREEN".  I.e., ordering units to hold fire.
2. Halves chance of suppression when enemy is merely 'detected' at not actually considered a target easy to fire at.
3. Removes needReload which wasn't all that successful and also quite slow.

**Refines tacticsAssess:**
* Adds and applies "RANGE_NEAR" define
* Removes Suppression chance when combatMode is "white" -- i.e., group is supposed to hold fire.
* Minor performance improvements by using getPosWorld and getPosATL where relevant

Changes in both functions make the AI less likely to become fully stuck in a suppression loop. Particularly when the enemy isn't actually spotted.
