### PR TITLE
Prevents sharing information to player group

### DIFF
--- a/addons/main/functions/fnc_doShareInformation.sqf
+++ b/addons/main/functions/fnc_doShareInformation.sqf
@@ -54,7 +54,8 @@ private _groups = allGroups select {
     _leader distance2D _unit < _range
     && {simulationEnabled (vehicle _leader)}
     && {((side _x) getFriend _side) > 0.6}
-    && {behaviour _leader isNotEqualTo "CARELESS"}
+    && {(behaviour _leader) isNotEqualTo "CARELESS"}
+    && {!isPlayer _leader}
     && {_x isNotEqualTo _group}
 };
 


### PR DESCRIPTION
Prevents sharing information to player led group. This has the benefit of stopping the group from entering "combat mode" outside the players control. While it does mean that player groups gain less information to engage targets at long range-- the _player_ is present. So that will rarely be an issue!
