### PR TITLE
Improve Suppression settings and stringtables

### DIFF
--- a/addons/main/functions/UnitAction/fnc_doSuppress.sqf
+++ b/addons/main/functions/UnitAction/fnc_doSuppress.sqf
@@ -11,7 +11,7 @@
  * success
  *
  * Example:
- * [bob, eyePos angryJoe] call lambs_main_fnc_suppress;
+ * [bob, eyePos angryJoe] call lambs_main_fnc_doSuppress;
  *
  * Public: No
 */
@@ -28,7 +28,7 @@ if (
 ) exitWith {false};
 
 // max range pos
-private _distance = (_eyePos vectorDistance _pos) min 280;
+private _distance = (_eyePos vectorDistance _pos) min 200;
 _pos = _eyePos vectorAdd ((_eyePos vectorFromTo _pos) vectorMultiply _distance);
 
 // adjust pos
@@ -57,7 +57,7 @@ _unit setVariable [QGVAR(currentTarget), _pos, GVAR(debug_functions)];
 
 // debug
 if (GVAR(debug_functions)) then {
-    ["%1 Suppression (%2 @ %3m)", side _unit, name _unit, round (_eyePos vectorDistance _pos)] call FUNC(debugLog);
+    ["%1 Suppression (%2 @ %3m)", side _unit, name _unit, round _distance] call FUNC(debugLog);
 
     private _sphere = createSimpleObject ["Sign_Sphere100cm_F", _pos, true];
     _sphere setObjectTexture [0, [_unit] call FUNC(debugObjectColor)];

--- a/addons/main/settings.sqf
+++ b/addons/main/settings.sqf
@@ -69,7 +69,7 @@ _curCat = LSTRING(Settings_SuppressionCat);
     "SLIDER",
     [LSTRING(Settings_MinSuppressDistance), LSTRING(Settings_MinSuppressDistance_ToolTip)],
     [COMPONENT_NAME, _curCat],
-    [1, 500, 28, 0],
+    [1, 500, 50, 0],
     1
 ] call CBA_fnc_addSetting;
 

--- a/addons/main/stringtable.xml
+++ b/addons/main/stringtable.xml
@@ -288,7 +288,7 @@
             <Russian>Минимальная дистанция для огня на подавление</Russian>
         </Key>
         <Key ID="STR_Lambs_Main_Settings_MinSuppressDistance_ToolTip">
-            <English>Within this distance AI will not perform suppression fire</English>
+            <English>If the target or a blocking obstacle is within this distance, the AI will not perform suppression fire</English>
             <German>Unter dieser Distanz führt die KI kein Unterdrückungsfeuer aus.</German>
             <Polish>Poniżej tej odległości AI nie strzela ogniem zaporowym</Polish>
             <Russian>На этом расстоянии ИИ не будет вести огонь на подавление</Russian>
@@ -300,7 +300,7 @@
             <Russian>Минимальная безопасная зона для  огня на подавление</Russian>
         </Key>
         <Key ID="STR_Lambs_Main_Settings_minFriendlySuppressionDistance_ToolTip">
-            <English>If there are allies within this distance AI will not perform suppression fire. Set to 0 to disable.</English>
+            <English>If there are allies within this distance, AI will not perform suppression fire. Set to 0 to disable.</English>
             <German>Wenn sich befreundete Einheiten innerhalb des Sicherheitsradius befinden für die KI kein Unterdrückungsfeuer durch. Auf 0 setzen um die Funktion zu deaktivieren.</German>
             <Polish>Jeśli w tym obszarze znajdują się sojusznicy, AI nie rozpocznie ognia zaporowego. Ustaw 0 żeby wyłączyć.</Polish>
             <Russian>Если на этом расстоянии есть союзники, ИИ не будет вести огонь на подавление. Установите 0, чтобы отключить</Russian>


### PR DESCRIPTION
### This branch does three things:

*Values*
1. Changes default value of minimum suppression distance from 28 to 50
2. Clarifies some stringtable text
3. Changes max range of suppression from 280 to 200

*Fixes*
- This means the AI will be less likely to suppress buildings and walls in built up terrain*
- This makes the AI more able to  suppress at range (specifically accounting for weapons like the vanilla AKM which are weirdly configured)*

**logic suppression value**
*For individual AI the change will be minimal. When the AI is within CQB range (by default 60 meters) that option will be preferred instead. For AI that are flanking or suppressing, the effect is more noticeable-- fewer instances of violently suppressing a bush or street sign infront of them.  Combat testing on Livonia demonstrates no problems in forest fights. 

**logic max range of suppression**
**Ideally, the best option would probably be to read the config of the weapon and get the maximum range where the AI would prefer to engage. I.e., a crossreference of max range and the likelihood of shooting weapon at that range.  In practice. 200M works fine.  It also makes the lambs_main_fnc_doSuppress function more reliable with a larger number of weapons. 

Before this fix, units equipped with AKM rifle would aim their weapon, but _not fire_ and be stuck in currentCommand "Suppress" until that timed out.  I.e., this is a fix.