### PR TITLE
Fixes circular flanking and prevents leaders from suppressing

### DIFF
--- a/addons/danger/functions/fnc_tacticsFlank.sqf
+++ b/addons/danger/functions/fnc_tacticsFlank.sqf
@@ -69,7 +69,7 @@ _pos pushBack _target;
 
 // find overwatch position
 if (_overwatch isEqualTo []) then {
-    private _distance2D = (_unit distance2D _target) min 250;
+    private _distance2D = ((_unit distance2D _target) * 0.66) min 250;
     _overwatch = selectBestPlaces [_target, _distance2D, "(2 * hills) + (2 * forest + trees + houses) - (2 * meadow) - (2 * windy) - (2 * sea) - (10 * deadBody)", 100 , 3] apply {[(_x select 0) distance2D _unit, _x select 0]};
     _overwatch = _overwatch select {!(surfaceIsWater (_x select 1))};
     _overwatch sort true;

--- a/addons/main/functions/GroupAction/fnc_doGroupFlank.sqf
+++ b/addons/main/functions/GroupAction/fnc_doGroupFlank.sqf
@@ -36,7 +36,11 @@ private _posASL = AGLtoASL (selectRandom _pos);
     _x setVariable [QEGVAR(danger,forceMove), !_suppressed];
 
     // suppress
-    if (RND(0.7) && {!(terrainIntersectASL [eyePos _x, _posASL vectorAdd [0, 0, 3]])}) then {
+    if (
+        RND(0.7)
+        && {(leader _x) isNotEqualTo _x}
+        && {!(terrainIntersectASL [eyePos _x, _posASL vectorAdd [0, 0, 3]])}
+    ) then {
         [{_this call FUNC(doSuppress)}, [_x, _posASL vectorAdd [0, 0, random 1]], random 3] call CBA_fnc_waitAndExecute;
     };
 } foreach _units;


### PR DESCRIPTION
### This branch improves two things:
1. Stops AI leaders from supressing while flanking
2. Fixes AI Flanking manoeuvres never closing in to destroy the enemy!

**FIXES LEADERS**
By stopping AI leaders from being picked to deliver suppressive fire. Group cohesion is improved and prevents a few cases where AI group leaders would get stuck when flanking.

**FIXES TACTICS**
By  reducing evaluated distance L72 in fn_tacticsFlank.sqf  we ensure that the AI actually close with and destroy the enemy!  This prevents a few border cases where the AI was seen never to attempt to close in with the enemy and would instead be seen to circle hopelessly around the target.
