### PR TITLE
Fix assault/garrison issue with taskAssess

### DIFF
--- a/addons/danger/functions/fnc_tacticsAssess.sqf
+++ b/addons/danger/functions/fnc_tacticsAssess.sqf
@@ -108,7 +108,7 @@ if !(_enemies isEqualTo [] || {_unitCount < random 3}) then {
     };
     if (_nearIndoorTarget != -1) exitWith {
         _plan append [TACTICS_GARRISON, TACTICS_ASSAULT, TACTICS_ASSAULT];
-        _pos = [_unit getHideFrom (_enemies select _nearIndoorTarget), _eyePos] select _inside;
+        _pos = getPosATL (_enemies select _nearIndoorTarget);
     };
 
     // inside? stay safe


### PR DESCRIPTION
### Fixes - occassionally units would pick completely wrong buildings to assault.
1. When group leader was already indoor in a different building
2. When assumed location of AI was away from buildings
