### PR TITLE
Fix units attacking SuppressTargets

### DIFF
--- a/addons/danger/functions/fnc_brainForced.sqf
+++ b/addons/danger/functions/fnc_brainForced.sqf
@@ -41,9 +41,11 @@ if (fleeing _unit) exitWith {
 
 // attack speed and stance
 if ((currentCommand _unit) isEqualTo "ATTACK") then {
-    _unit setVariable [QEGVAR(main,currentTask), "Attacking", EGVAR(main,debug_functions)];
-    [_unit, getAttackTarget _unit] call EFUNC(main,doAssaultSpeed);
+    private _attackTarget = getAttackTarget _unit;
+    if ((typeOf _attackTarget) isEqualTo "SuppressTarget") exitWith {deleteVehicle _attackTarget;};
+    [_unit, _attackTarget] call EFUNC(main,doAssaultSpeed);
     _unit setUnitPosWeak (["MIDDLE", "PRONE"] select (getSuppression _unit > 0.9));
+    _unit setVariable [QEGVAR(main,currentTask), "Attacking", EGVAR(main,debug_functions)];
 };
 
 // end


### PR DESCRIPTION
### When merged this pull request will:
LAMBS Danger.fsm adds more instances of the local vehicle "SuppressTarget". On occasion, units will chose them as valid 'ATTACK' targets.  This causes them to stupidly shoot at single locations.

Seems like a vanilla error where SuppressTargets are not always cleaned up.

This, crudely, fixes this by simply deleting suppressTargets which have turned into objects that are instead attacked.
