### PR TITLE
Improve taskCamp, taskCamp and taskGarrison waypoints with eventhandlers

### DIFF
--- a/addons/main/XEH_PREP.hpp
+++ b/addons/main/XEH_PREP.hpp
@@ -22,6 +22,8 @@ PREP(isNight);
 PREP(showDialog);
 PREP(parseData);
 
+PREP(removeEventhandlers);
+
 SUBPREP(GroupAction,doGroupAssault);
 SUBPREP(GroupAction,doGroupFlank);
 SUBPREP(GroupAction,doGroupSuppress);

--- a/addons/main/functions/fnc_removeEventhandlers.sqf
+++ b/addons/main/functions/fnc_removeEventhandlers.sqf
@@ -1,0 +1,20 @@
+#include "script_component.hpp"
+/*
+ * Author: nkenny
+ * Removes eventhandlers assigned by lambs modules
+ *
+ * Arguments:
+ * 0: Unit to clean up <OBJECT>
+ *
+ * Return Value:
+ * nil
+ *
+ * Example:
+ * [bob] call lambs_main_removeEventhandlers;
+ *
+ * Public: No
+*/
+params ["_unit", "_ehs"];
+{
+    _unit removeEventHandler _x;
+} forEach _ehs;

--- a/addons/wp/XEH_preInit.sqf
+++ b/addons/wp/XEH_preInit.sqf
@@ -78,5 +78,14 @@ if (isServer) then {
     _this spawn FUNC(taskRush);
 }] call CBA_fnc_addEventhandler;
 
+[QGVAR(taskCampReset), {
+    params ["_unit"];
+    {
+        _x enableAI 'ANIM';
+        _x enableAI 'PATH';
+    } foreach (units _unit);
+    [_unit, "", 2] call EFUNC(main,doAnimation);
+    _unit setUnitPos "AUTO";
+}] call CBA_fnc_addEventhandler;
 
 ADDON = true;

--- a/addons/wp/XEH_preInit.sqf
+++ b/addons/wp/XEH_preInit.sqf
@@ -83,6 +83,8 @@ if (isServer) then {
     {
         _x enableAI 'ANIM';
         _x enableAI 'PATH';
+        [_x, _x getVariable [QGVAR(eventhandlers), []]] call EFUNC(main,removeEventhandlers);
+        _x setVariable [QGVAR(eventhandlers), nil];
     } foreach (units _unit);
     [_unit, "", 2] call EFUNC(main,doAnimation);
     _unit setUnitPos "AUTO";

--- a/addons/wp/functions/Modules/fnc_moduleGarrison.sqf
+++ b/addons/wp/functions/Modules/fnc_moduleGarrison.sqf
@@ -32,7 +32,7 @@ switch (_mode) do {
                     [
                         [LSTRING(Groups_DisplayName), "DROPDOWN", LSTRING(Groups_ToolTip), _groups apply { format ["%1 - %2 (%3 m)", side _x, groupId _x, round ((leader _x) distance _logic)] }, 0],
                         [LSTRING(Module_TaskGarrison_Radius_DisplayName), "SLIDER", LSTRING(Module_TaskGarrison_Radius_ToolTip), [10, 500], [2, 1], TASK_GARRISON_SIZE, 2],
-                        [LSTRING(Module_TaskGarrison_ExitCondition_DisplayName), "DROPDOWN", LSTRING(Module_TaskGarrison_ExitCondition_Tooltip), [LSTRING(Random), LSTRING(All), LSTRING(FiredNear), LSTRING(Fired), LSTRING(Hit), LSTRING(None)], TASK_GARRISON_EXITCONDITIONS + 2],
+                        [LSTRING(Module_TaskGarrison_ExitCondition_DisplayName), "DROPDOWN", LSTRING(Module_TaskGarrison_ExitCondition_Tooltip), [LSTRING(Random), LSTRING(All), LSTRING(FiredNear), LSTRING(Fired), LSTRING(Hit), LSTRING(Suppressed), LSTRING(None)], TASK_GARRISON_EXITCONDITIONS + 2],
                         [LSTRING(Module_TaskGarrison_SortByHeight_DisplayName), "BOOLEAN", LSTRING(Module_TaskGarrison_SortByHeight_Tooltip), TASK_GARRISON_SORTBYHEIGHT],
                         [LSTRING(Module_TaskGarrison_Teleport_DisplayName), "BOOLEAN", LSTRING(Module_TaskGarrison_Teleport_Tooltip), TASK_GARRISON_TELEPORT],
                         [LSTRING(Module_TaskGarrison_Patrol_DisplayName), "BOOLEAN", LSTRING(Module_TaskGarrison_Patrol_Tooltip), TASK_GARRISON_PATROL]
@@ -61,7 +61,7 @@ switch (_mode) do {
                     [
                         [LSTRING(Centers_DisplayName), "DROPDOWN", LSTRING(Centers_ToolTip), _targets apply {  format ["%1 (%2 m)", vehicleVarName _x, round (_x distance _logic)] }, 0],
                         [LSTRING(Module_TaskGarrison_Radius_DisplayName), "SLIDER", LSTRING(Module_TaskGarrison_Radius_ToolTip), [10, 500], [2, 1], TASK_GARRISON_SIZE, 2],
-                        [LSTRING(Module_TaskGarrison_ExitCondition_DisplayName), "DROPDOWN", LSTRING(Module_TaskGarrison_ExitCondition_Tooltip), [LSTRING(Random), LSTRING(All), LSTRING(FiredNear), LSTRING(Fired), LSTRING(Hit), LSTRING(None)], TASK_GARRISON_EXITCONDITIONS + 2],
+                        [LSTRING(Module_TaskGarrison_ExitCondition_DisplayName), "DROPDOWN", LSTRING(Module_TaskGarrison_ExitCondition_Tooltip), [LSTRING(Random), LSTRING(All), LSTRING(FiredNear), LSTRING(Fired), LSTRING(Hit), LSTRING(Suppressed), LSTRING(None)], TASK_GARRISON_EXITCONDITIONS + 2],
                         [LSTRING(Module_TaskGarrison_SortByHeight_DisplayName), "BOOLEAN", LSTRING(Module_TaskGarrison_SortByHeight_Tooltip), TASK_GARRISON_SORTBYHEIGHT],
                         [LSTRING(Module_TaskGarrison_Teleport_DisplayName), "BOOLEAN", LSTRING(Module_TaskGarrison_Teleport_Tooltip), TASK_GARRISON_TELEPORT],
                         [LSTRING(Module_TaskGarrison_Patrol_DisplayName), "BOOLEAN", LSTRING(Module_TaskGarrison_Patrol_Tooltip), TASK_GARRISON_PATROL]

--- a/addons/wp/functions/Modules/fnc_moduleGarrison.sqf
+++ b/addons/wp/functions/Modules/fnc_moduleGarrison.sqf
@@ -32,7 +32,7 @@ switch (_mode) do {
                     [
                         [LSTRING(Groups_DisplayName), "DROPDOWN", LSTRING(Groups_ToolTip), _groups apply { format ["%1 - %2 (%3 m)", side _x, groupId _x, round ((leader _x) distance _logic)] }, 0],
                         [LSTRING(Module_TaskGarrison_Radius_DisplayName), "SLIDER", LSTRING(Module_TaskGarrison_Radius_ToolTip), [10, 500], [2, 1], TASK_GARRISON_SIZE, 2],
-                        [LSTRING(Module_TaskGarrison_ExitCondition_DisplayName), "DROPDOWN", LSTRING(Module_TaskGarrison_ExitCondition_Tooltip), [LSTRING(Random), LSTRING(All), LSTRING(FiredNear), LSTRING(Fired), LSTRING(Hit), LSTRING(Suppressed), LSTRING(None)], TASK_GARRISON_EXITCONDITIONS + 2],
+                        [LSTRING(Module_TaskGarrison_ExitCondition_DisplayName), "DROPDOWN", LSTRING(Module_TaskGarrison_ExitCondition_Tooltip), [LSTRING(Random), LSTRING(All), LSTRING(None), LSTRING(Hit), LSTRING(Fired), LSTRING(FiredNear), LSTRING(Suppressed)], TASK_GARRISON_EXITCONDITIONS + 2],
                         [LSTRING(Module_TaskGarrison_SortByHeight_DisplayName), "BOOLEAN", LSTRING(Module_TaskGarrison_SortByHeight_Tooltip), TASK_GARRISON_SORTBYHEIGHT],
                         [LSTRING(Module_TaskGarrison_Teleport_DisplayName), "BOOLEAN", LSTRING(Module_TaskGarrison_Teleport_Tooltip), TASK_GARRISON_TELEPORT],
                         [LSTRING(Module_TaskGarrison_Patrol_DisplayName), "BOOLEAN", LSTRING(Module_TaskGarrison_Patrol_Tooltip), TASK_GARRISON_PATROL]
@@ -61,7 +61,7 @@ switch (_mode) do {
                     [
                         [LSTRING(Centers_DisplayName), "DROPDOWN", LSTRING(Centers_ToolTip), _targets apply {  format ["%1 (%2 m)", vehicleVarName _x, round (_x distance _logic)] }, 0],
                         [LSTRING(Module_TaskGarrison_Radius_DisplayName), "SLIDER", LSTRING(Module_TaskGarrison_Radius_ToolTip), [10, 500], [2, 1], TASK_GARRISON_SIZE, 2],
-                        [LSTRING(Module_TaskGarrison_ExitCondition_DisplayName), "DROPDOWN", LSTRING(Module_TaskGarrison_ExitCondition_Tooltip), [LSTRING(Random), LSTRING(All), LSTRING(FiredNear), LSTRING(Fired), LSTRING(Hit), LSTRING(Suppressed), LSTRING(None)], TASK_GARRISON_EXITCONDITIONS + 2],
+                        [LSTRING(Module_TaskGarrison_ExitCondition_DisplayName), "DROPDOWN", LSTRING(Module_TaskGarrison_ExitCondition_Tooltip), [LSTRING(Random), LSTRING(All), LSTRING(None), LSTRING(Hit), LSTRING(Fired), LSTRING(FiredNear), LSTRING(Suppressed)], TASK_GARRISON_EXITCONDITIONS + 2],
                         [LSTRING(Module_TaskGarrison_SortByHeight_DisplayName), "BOOLEAN", LSTRING(Module_TaskGarrison_SortByHeight_Tooltip), TASK_GARRISON_SORTBYHEIGHT],
                         [LSTRING(Module_TaskGarrison_Teleport_DisplayName), "BOOLEAN", LSTRING(Module_TaskGarrison_Teleport_Tooltip), TASK_GARRISON_TELEPORT],
                         [LSTRING(Module_TaskGarrison_Patrol_DisplayName), "BOOLEAN", LSTRING(Module_TaskGarrison_Patrol_Tooltip), TASK_GARRISON_PATROL]

--- a/addons/wp/functions/fnc_taskCamp.sqf
+++ b/addons/wp/functions/fnc_taskCamp.sqf
@@ -199,21 +199,19 @@ private _dir = random 360;
         _unit disableAI "PATH";
         _unit setDir (_unit getDir _center);
         _unit setUnitPos "MIDDLE";
-        _unit addEventHandler ["Hit", {
+        private _handleHit = _unit addEventHandler ["Hit", {
             params ["_unit"];
             [QGVAR(taskCampReset), _unit, _unit] call CBA_fnc_targetEvent;
-            _unit removeEventHandler ["Hit", _thisEventHandler];
         }];
-        _unit addEventHandler ["FiredNear", {
+        private _handleFiredNear = _unit addEventHandler ["FiredNear", {
             params ["_unit"];
             [QGVAR(taskCampReset), _unit, _unit] call CBA_fnc_targetEvent;
-            _unit removeEventHandler ["FiredNear", _thisEventHandler];
         }];
-        _unit addEventHandler ["Suppressed", {
+        private _handleSuppressed = _unit addEventHandler ["Suppressed", {
             params ["_unit"];
             [QGVAR(taskCampReset), _unit, _unit] call CBA_fnc_targetEvent;
-            _unit removeEventHandler ["Suppressed", _thisEventHandler];
         }];
+        _unit setVariable [QGVAR(eventhandlers), [["Hit", _handleHit], ["FiredNear", _handleFiredNear], ["Suppressed", _handleSuppressed]]];
     }, [_x, _campPos, _pos, selectRandom _anims]] call CBA_fnc_waitUntilAndExecute;
 } forEach _units;
 

--- a/addons/wp/functions/fnc_taskGarrison.sqf
+++ b/addons/wp/functions/fnc_taskGarrison.sqf
@@ -125,7 +125,7 @@ private _fnc_addEventHandler = {
     };
 
     // variables
-    private _ehs = _unit getVariable [QGVAR(eventhandlers), []];
+    private _ehs = _x getVariable [QGVAR(eventhandlers), []];
 
     // add handlers
     switch (_type) do {
@@ -171,7 +171,7 @@ private _fnc_addEventHandler = {
     };
 
     // set EH
-    _unit setVariable [QGVAR(eventhandlers), _ehs];
+    _x setVariable [QGVAR(eventhandlers), _ehs];
 };
 // spread out
 {
@@ -207,7 +207,7 @@ private _fnc_addEventHandler = {
     };
 
     if (_exitCondition == -1) then {
-        for "_i" from 0 to 3 do {
+        for "_i" from 0 to 4 do {
             _i call _fnc_addEventHandler;
         };
     } else {

--- a/addons/wp/functions/fnc_taskGarrison.sqf
+++ b/addons/wp/functions/fnc_taskGarrison.sqf
@@ -119,12 +119,13 @@ _units = _units - [objNull];
 if (count _units > count _houses) then {_units resize (count _houses);};
 private _fnc_addEventHandler = {
     params ["_type"];
+    if (_type == 0) exitWith {};
     if (_type == -2) then {
         _type = floor (random 4);
     };
     // add handlers
     switch (_type) do {
-        case 0: {
+        case 1: {
             _x addEventHandler ["Hit", {
                 params ["_unit"];
                 [_unit, "PATH"] remoteExec ["enableAI", _unit];
@@ -132,7 +133,7 @@ private _fnc_addEventHandler = {
                 _unit removeEventHandler ["Hit", _thisEventHandler];
             }];
         };
-        case 1: {
+        case 2: {
             _x addEventHandler ["Fired", {
                 params ["_unit"];
                 [_unit, "PATH"] remoteExec ["enableAI", _unit];
@@ -140,7 +141,7 @@ private _fnc_addEventHandler = {
                 _unit removeEventHandler ["Fired", _thisEventHandler];
             }];
         };
-        case 2: {
+        case 3: {
             _x addEventHandler ["FiredNear", {
                 params ["_unit", "_shooter", "_distance"];
                 if (side _unit != side _shooter && {_distance < (10 + random 10)}) then {
@@ -151,16 +152,13 @@ private _fnc_addEventHandler = {
                 };
             }];
         };
-        case 3: {
+        case 4: {
             _x addEventHandler ["Suppressed", {
                 params ["_unit"];
                 [_unit, "PATH"] remoteExec ["enableAI", _unit];
                 _unit setCombatMode "RED";
                 _unit removeEventHandler ["Suppressed", _thisEventHandler];
             }];
-        };
-        case 4: {
-            // DO NOTHING
         };
     };
 };

--- a/addons/wp/functions/fnc_taskGarrison.sqf
+++ b/addons/wp/functions/fnc_taskGarrison.sqf
@@ -118,19 +118,19 @@ _units = _units - [objNull];
 // enter buildings
 if (count _units > count _houses) then {_units resize (count _houses);};
 private _fnc_addEventHandler = {
-    params ["_type"];
+    params ["_unit", "_type"];
     if (_type == 0) exitWith {};
     if (_type == -2) then {
         _type = floor (random 4);
     };
 
     // variables
-    private _ehs = _x getVariable [QGVAR(eventhandlers), []];
+    private _ehs = _unit getVariable [QGVAR(eventhandlers), []];
 
     // add handlers
     switch (_type) do {
         case 1: {
-            private _handle = _x addEventHandler ["Hit", {
+            private _handle = _unit addEventHandler ["Hit", {
                 params ["_unit"];
                 [_unit, "PATH"] remoteExec ["enableAI", _unit];
                 _unit setCombatMode "RED";
@@ -139,7 +139,7 @@ private _fnc_addEventHandler = {
             _ehs pushBack ["Hit", _handle];
         };
         case 2: {
-            private _handle = _x addEventHandler ["Fired", {
+            private _handle = _unit addEventHandler ["Fired", {
                 params ["_unit"];
                 [_unit, "PATH"] remoteExec ["enableAI", _unit];
                 _unit setCombatMode "RED";
@@ -148,7 +148,7 @@ private _fnc_addEventHandler = {
             _ehs pushBack ["Fired", _handle];
         };
         case 3: {
-            private _handle = _x addEventHandler ["FiredNear", {
+            private _handle = _unit addEventHandler ["FiredNear", {
                 params ["_unit", "_shooter", "_distance"];
                 if (side _unit != side _shooter && {_distance < (10 + random 10)}) then {
                     [_unit, "PATH"] remoteExec ["enableAI", _unit];
@@ -160,7 +160,7 @@ private _fnc_addEventHandler = {
             _ehs pushBack ["FiredNear", _handle];
         };
         case 4: {
-            private _handle = _x addEventHandler ["Suppressed", {
+            private _handle = _unit addEventHandler ["Suppressed", {
                 params ["_unit"];
                 [_unit, "PATH"] remoteExec ["enableAI", _unit];
                 _unit setCombatMode "RED";
@@ -171,7 +171,7 @@ private _fnc_addEventHandler = {
     };
 
     // set EH
-    _x setVariable [QGVAR(eventhandlers), _ehs];
+    _unit setVariable [QGVAR(eventhandlers), _ehs];
 };
 // spread out
 {
@@ -208,10 +208,10 @@ private _fnc_addEventHandler = {
 
     if (_exitCondition == -1) then {
         for "_i" from 0 to 4 do {
-            _i call _fnc_addEventHandler;
+            [_x, _i] call _fnc_addEventHandler;
         };
     } else {
-        _exitCondition call _fnc_addEventHandler;
+        [_x, _exitCondition] call _fnc_addEventHandler;
     };
 
 } forEach _units;

--- a/addons/wp/functions/fnc_taskGarrison.sqf
+++ b/addons/wp/functions/fnc_taskGarrison.sqf
@@ -123,26 +123,32 @@ private _fnc_addEventHandler = {
     if (_type == -2) then {
         _type = floor (random 4);
     };
+
+    // variables
+    private _ehs = _unit getVariable [QGVAR(eventhandlers), []];
+
     // add handlers
     switch (_type) do {
         case 1: {
-            _x addEventHandler ["Hit", {
+            private _handle = _x addEventHandler ["Hit", {
                 params ["_unit"];
                 [_unit, "PATH"] remoteExec ["enableAI", _unit];
                 _unit setCombatMode "RED";
                 _unit removeEventHandler ["Hit", _thisEventHandler];
             }];
+            _ehs pushBack ["Hit", _handle];
         };
         case 2: {
-            _x addEventHandler ["Fired", {
+            private _handle = _x addEventHandler ["Fired", {
                 params ["_unit"];
                 [_unit, "PATH"] remoteExec ["enableAI", _unit];
                 _unit setCombatMode "RED";
                 _unit removeEventHandler ["Fired", _thisEventHandler];
             }];
+            _ehs pushBack ["Fired", _handle];
         };
         case 3: {
-            _x addEventHandler ["FiredNear", {
+            private _handle = _x addEventHandler ["FiredNear", {
                 params ["_unit", "_shooter", "_distance"];
                 if (side _unit != side _shooter && {_distance < (10 + random 10)}) then {
                     [_unit, "PATH"] remoteExec ["enableAI", _unit];
@@ -151,16 +157,21 @@ private _fnc_addEventHandler = {
                     _unit removeEventHandler ["FiredNear", _thisEventHandler];
                 };
             }];
+            _ehs pushBack ["FiredNear", _handle];
         };
         case 4: {
-            _x addEventHandler ["Suppressed", {
+            private _handle = _x addEventHandler ["Suppressed", {
                 params ["_unit"];
                 [_unit, "PATH"] remoteExec ["enableAI", _unit];
                 _unit setCombatMode "RED";
                 _unit removeEventHandler ["Suppressed", _thisEventHandler];
             }];
+            _ehs pushBack ["Suppressed", _handle];
         };
     };
+
+    // set EH
+    _unit setVariable [QGVAR(eventhandlers), _ehs];
 };
 // spread out
 {

--- a/addons/wp/functions/fnc_taskGarrison.sqf
+++ b/addons/wp/functions/fnc_taskGarrison.sqf
@@ -134,7 +134,8 @@ private _fnc_addEventHandler = {
                 params ["_unit"];
                 [_unit, "PATH"] remoteExec ["enableAI", _unit];
                 _unit setCombatMode "RED";
-                _unit removeEventHandler ["Hit", _thisEventHandler];
+                [_unit, _unit getVariable [GVAR(eventhandlers), []]] call EFUNC(main,removeEventhandlers);
+                _unit setVariable [QGVAR(eventhandlers), nil];
             }];
             _ehs pushBack ["Hit", _handle];
         };
@@ -143,7 +144,8 @@ private _fnc_addEventHandler = {
                 params ["_unit"];
                 [_unit, "PATH"] remoteExec ["enableAI", _unit];
                 _unit setCombatMode "RED";
-                _unit removeEventHandler ["Fired", _thisEventHandler];
+                [_unit, _unit getVariable [GVAR(eventhandlers), []]] call EFUNC(main,removeEventhandlers);
+                _unit setVariable [QGVAR(eventhandlers), nil];
             }];
             _ehs pushBack ["Fired", _handle];
         };
@@ -154,7 +156,8 @@ private _fnc_addEventHandler = {
                     [_unit, "PATH"] remoteExec ["enableAI", _unit];
                     _unit doMove (getPosATL _shooter);
                     _unit setCombatMode "RED";
-                    _unit removeEventHandler ["FiredNear", _thisEventHandler];
+                    [_unit, _unit getVariable [GVAR(eventhandlers), []]] call EFUNC(main,removeEventhandlers);
+                    _unit setVariable [QGVAR(eventhandlers), nil];
                 };
             }];
             _ehs pushBack ["FiredNear", _handle];
@@ -164,7 +167,8 @@ private _fnc_addEventHandler = {
                 params ["_unit"];
                 [_unit, "PATH"] remoteExec ["enableAI", _unit];
                 _unit setCombatMode "RED";
-                _unit removeEventHandler ["Suppressed", _thisEventHandler];
+                [_unit, _unit getVariable [GVAR(eventhandlers), []]] call EFUNC(main,removeEventhandlers);
+                _unit setVariable [QGVAR(eventhandlers), nil];
             }];
             _ehs pushBack ["Suppressed", _handle];
         };

--- a/addons/wp/functions/fnc_taskHunt.sqf
+++ b/addons/wp/functions/fnc_taskHunt.sqf
@@ -22,10 +22,12 @@
  *
  * Public: Yes
 */
+
 if !(canSuspend) exitWith {
     _this spawn FUNC(taskHunt);
 };
-// 1. FIND TRACKER
+
+// init
 params [
     ["_group", grpNull, [grpNull, objNull]],
     ["_radius", TASK_HUNT_SIZE, [0]],
@@ -36,11 +38,22 @@ params [
     ["_enableReinforcement", TASK_HUNT_ENABLEREINFORCEMENT, [false]]
 ];
 
+// functions ---
+
+// shoot flare
+private _fnc_flare = {
+    params ["_leader"];
+    private _shootflare = "F_20mm_Red" createvehicle (_leader ModelToWorld [0, 0, 200]);
+    _shootflare setVelocity [0, 0, -10];
+};
+
+// functions end ---
+
 // sort grp
 if (!local _group) exitWith {false};
 if (_group isEqualType objNull) then { _group = group _group; };
 
-// 2. SET GROUP BEHAVIOR
+// orders
 _group setbehaviour "SAFE";
 _group setSpeedMode "LIMITED";
 _group enableAttack false;
@@ -53,16 +66,7 @@ if (_enableReinforcement) then {
     _group setVariable [QEGVAR(danger,enableGroupReinforce), true, true];
 };
 
-// FUNCTIONS -------------------------------------------------------------
-
-// FLARE SCRIPT
-private _fnc_flare = {
-    params ["_leader"];
-    private _shootflare = "F_20mm_Red" createvehicle (_leader ModelToWorld [0, 0, 200]);
-    _shootflare setVelocity [0, 0, -10];
-};
-
-// 3. DO THE HUNT SCRIPT! ---------------------------------------------------
+// hunt loop
 waitUntil {
 
     // performance
@@ -73,35 +77,26 @@ waitUntil {
 
     // settings
     private _combat = (behaviour (leader _group)) isEqualTo "COMBAT";
-    private _onFoot = (isNull objectParent (leader _group));
+    private _onFoot = isNull (objectParent (leader _group));
 
     // give orders
     if (!isNull _target) then {
-        _group move (_target getPos [random (linearConversion [50, 1000, (leader _group) distance _target, 25, 300, true]), random 360]);
+        _group move (_target getPos [random (linearConversion [50, 1000, (leader _group) distance2D _target, 25, 300, true]), random 360]);
         _group setFormDir ((leader _group) getDir _target);
         _group setSpeedMode "NORMAL";
         _group enableGunLights "forceOn";
         _group enableIRLasers true;
 
         // debug
-        if (EGVAR(main,debug_functions)) then {["%1 taskHunt: %2 targets %3 at %4M", side _group, groupID _group, name _target, floor (leader _group distance _target)] call EFUNC(main,debugLog);};
+        if (EGVAR(main,debug_functions)) then {["%1 taskHunt: %2 targets %3 at %4M", side _group, groupID _group, name _target, floor (leader _group distance2D _target)] call EFUNC(main,debugLog);};
 
         // flare
         if (!_combat && {_onFoot} && {RND(0.8)}) then { [leader _group] call _fnc_flare; };
-
-        // suppress nearby buildings
-        if (_combat && {(nearestBuilding _target distance2D _target < 25)}) then {
-            {
-                [_x, getPosASL _target] call EFUNC(main,doSuppress);
-                true
-            } count units _group;
-        };
     };
 
-    // WAIT FOR IT! / end
+    // wait for it or end
     sleep _cycle;
-    ((units _group) findIf {_x call EFUNC(main,isAlive)} == -1)
-
+    (units _group) findIf {_x call EFUNC(main,isAlive)} == -1
 };
 
 // end

--- a/addons/wp/functions/fnc_taskReset.sqf
+++ b/addons/wp/functions/fnc_taskReset.sqf
@@ -71,6 +71,10 @@ private _leader = leader _group;
     _x setVariable [QEGVAR(danger,disableAI), nil, true];
     _x setVariable [QEGVAR(danger,forceMove), nil, true];
 
+    // LAMBS eventhandlers
+    [_x, _x getVariable [QGVAR(eventhandlers), []]] call EFUNC(main,removeEventhandlers);
+    _x setVariable [QGVAR(eventhandlers), nil];
+
     // rejoin
     _x doFollow _leader;
 } count _units;

--- a/addons/wp/modules.hpp
+++ b/addons/wp/modules.hpp
@@ -288,24 +288,24 @@ class GVAR(TaskGarrison) : GVAR(BaseModule) {
                     name = CSTRING(All);
                     value = -1;
                 };
+                class None {
+                    name = CSTRING(None);
+                    value = 0;
+                };
                 class Hit {
                     name = CSTRING(Hit);
-                    value = 0;
+                    value = 1;
                 };
                 class Fired {
                     name = CSTRING(Fired);
-                    value = 1;
+                    value = 2;
                 };
                 class FiredNear {
                     name = CSTRING(FiredNear);
-                    value = 2;
+                    value = 3;
                 };
                 class Suppressed {
                     name = CSTRING(Suppressed);
-                    value = 3;
-                };
-                class None {
-                    name = CSTRING(None);
                     value = 4;
                 };
             };

--- a/addons/wp/modules.hpp
+++ b/addons/wp/modules.hpp
@@ -300,9 +300,13 @@ class GVAR(TaskGarrison) : GVAR(BaseModule) {
                     name = CSTRING(FiredNear);
                     value = 2;
                 };
+                class Suppressed {
+                    name = CSTRING(Suppressed);
+                    value = 3;
+                };
                 class None {
                     name = CSTRING(None);
-                    value = 3;
+                    value = 4;
                 };
             };
         };

--- a/addons/wp/stringtable.xml
+++ b/addons/wp/stringtable.xml
@@ -654,6 +654,9 @@
             <Polish>Trafienie</Polish>
             <Russian>Ранение</Russian>
         </Key>
+        <Key ID="STR_Lambs_WP_Suppressed">
+            <English>Suppressed</English>
+        </Key>
         <Key ID="STR_Lambs_WP_SettingIsOnlyForLocalGroups">
             <English>'%1' is only Posible if the Group is local</English>
             <Polish>'%1' jest tylko możliwa, jeśli Grupa jest lokalna</Polish>


### PR DESCRIPTION
### When merged this pull request will:
Adds suppression EH to taskGarrison and taskCamp and makes taskHunt closer in style to other functions.

Adds taskCampReset event
Adds 'suppress' as an option to taskGarrison
Adds suppress check to taskCamp
Fixes wrong eventhandlers were selected in garrison module
Improves stance control of units in taskCamp
Improves taskHunt style
Improves cleanups of EHs
Removes suppression feature in taskHunt (better handled through new FSM and group actions)
Changed - order of eventhandlers
