### PR TITLE
Move panic feature from brain to eventhhandlers

### DIFF
--- a/addons/danger/functions/fnc_brain.sqf
+++ b/addons/danger/functions/fnc_brain.sqf
@@ -27,7 +27,6 @@
         Hide actions
         5 DeadBodyGroup
         6 DeadBody
-        - Panic
 
         Engage actions
         0 Enemy detected
@@ -109,15 +108,7 @@ if (_dangerCause in [DANGER_ENEMYDETECTED, DANGER_ENEMYNEAR, DANGER_CANFIRE]) ex
 };
 
 // hide actions
-private _panic = RND(1 - GVAR(panicChance)) && {getSuppression _unit > 0.9};
-if (_panic || {_dangerCause in [DANGER_DEADBODYGROUP, DANGER_DEADBODY, DANGER_SCREAM]}) exitWith {
-
-    // panic function
-    if (_panic) then {
-        [_unit] call EFUNC(main,doPanic);
-    };
-
-    // return
+if (_dangerCause in [DANGER_DEADBODYGROUP, DANGER_DEADBODY, DANGER_SCREAM]) exitWith {
     _return set [ACTION_HIDE, true];
     _return
 };

--- a/addons/danger/functions/fnc_brainHide.sqf
+++ b/addons/danger/functions/fnc_brainHide.sqf
@@ -22,7 +22,6 @@
     5 DeadBodyGroup
     6 DeadBody
     7 Hide
-    - Panic
 */
 
 params ["_unit", ["_type", -1], ["_pos", [0, 0, 0]]];

--- a/addons/danger/settings.sqf
+++ b/addons/danger/settings.sqf
@@ -100,17 +100,6 @@ private _curCat = LSTRING(Settings_GeneralCat);
     1
 ] call CBA_fnc_addSetting;
 
-
-// Chance of panic expressed as percentage
-[
-    QGVAR(panicChance),
-    "SLIDER",
-    [LSTRING(Settings_PanicChance), LSTRING(Settings_PanicChance_ToolTip)],
-    [COMPONENT_NAME, _curCat],
-    [0, 1, 0.1, 2, true],
-    1
-] call CBA_fnc_addSetting;
-
 /*
 TEMPORARILY DISABLED FOR VERSION 2.5 RELEASE
 WAITING BETTER OR OTHER SOLUTION

--- a/addons/danger/stringtable.xml
+++ b/addons/danger/stringtable.xml
@@ -183,18 +183,6 @@
             <Polish>Określa zasięg ataku</Polish>
             <Russian>Дальность, на которой юниты считают себя атакующими</Russian>
         </Key>
-        <Key ID="STR_Lambs_Danger_Settings_PanicChance">
-            <English>Panic Chance</English>
-            <German>Panikwahrscheinlichkeit</German>
-            <Polish>Szansa na panikę</Polish>
-            <Russian>Шанс паники</Russian>
-        </Key>
-        <Key ID="STR_Lambs_Danger_Settings_PanicChance_ToolTip">
-            <English>Chance to panic in percentage</English>
-            <German>Die Wahrscheinlichkeit in Panik zu verfallen in Prozent.</German>
-            <Polish>Szansa, że jednostka spanikuje, wyrażona w procentach</Polish>
-            <Russian>Шанс паники в процентах</Russian>
-        </Key>
         <Key ID="STR_Lambs_Danger_Settings_CQBFormation">
             <English>Units set to CQB formations will methodically clear buildings when an enemy is encountered</English>
             <German>Einheiten die in CQB-Formationen gesetzt werden, werden bei Feindkontakt methodisch Häuser säubern.</German>

--- a/addons/eventhandlers/CfgEventHandlers.hpp
+++ b/addons/eventhandlers/CfgEventHandlers.hpp
@@ -22,3 +22,11 @@ class Extended_Explosion_Eventhandlers {
         };
     };
 };
+
+class Extended_Suppressed_Eventhandlers {
+    class CAManBase {
+        class LAMBS_CAManBase_suppressed {
+            Suppressed = QUOTE(_this call FUNC(suppressedEH));
+        };
+    };
+};

--- a/addons/eventhandlers/XEH_PREP.hpp
+++ b/addons/eventhandlers/XEH_PREP.hpp
@@ -1,1 +1,2 @@
 PREP(explosionEH);
+PREP(suppressedEH);

--- a/addons/eventhandlers/functions/fnc_suppressedEH.sqf
+++ b/addons/eventhandlers/functions/fnc_suppressedEH.sqf
@@ -1,0 +1,40 @@
+#include "script_component.hpp"
+/*
+ * Author: nkenny
+ * Suppression eventhandler that may trigger panic
+ *
+ * Arguments:
+ * 0: Unit  <OBJECT>
+ *
+ * Return Value:
+ * boolean
+ *
+ * Example:
+ * [bob] call lambs_eventhandlers_fnc_suppressionEH;
+ *
+ * Public: No
+*/
+
+// init
+params ["_unit"];
+if (
+    morale _unit > 0
+    || {getSuppression _unit < 0.97}
+    || {!local _unit}
+    || {!isNull objectParent _unit}
+    || {_unit getVariable [QEGVAR(danger,forceMove), false]}
+    || {_this getVariable [QEGVAR(danger,disableAI), false]}
+    || {RND(GVAR(panicChance))}
+    || {isPlayer _unit || {isPlayer (leader _unit)}}
+) exitWith {false};
+
+// doPanic
+_unit call EFUNC(main,doPanic);
+
+// debug informaiton to be removed before release -- nkenny
+systemchat "PANIC INITATED!";
+[_unit, format ["PANIC - %2 | %1", getSuppression _unit, morale _unit]] call lambs_main_fnc_dotMarker;
+// debug information!!!
+
+// end
+true

--- a/addons/eventhandlers/settings.sqf
+++ b/addons/eventhandlers/settings.sqf
@@ -17,3 +17,13 @@ private _curCat = LSTRING(Settings_Cat);
     [0, 25, 9, 2],
     true         // players may configure their own preferences
 ] call CBA_fnc_addSetting;
+
+// Chance of panic expressed as percentage
+[
+    QGVAR(panicChance),
+    "SLIDER",
+    [LSTRING(Settings_PanicChance), LSTRING(Settings_PanicChance_ToolTip)],
+    [COMPONENT_NAME, _curCat],
+    [0, 1, 0.1, 2, true],
+    1
+] call CBA_fnc_addSetting;

--- a/addons/eventhandlers/stringtable.xml
+++ b/addons/eventhandlers/stringtable.xml
@@ -31,5 +31,17 @@
             <Polish>Konfiguruje czas resetowania reakcji na zdarzenie wybuchu.</Polish>
             <Russian>Настраивает время сброса взрывов</Russian>
         </Key>
+        <Key ID="STR_Lambs_Danger_Settings_PanicChance">
+            <English>Panic Chance</English>
+            <German>Panikwahrscheinlichkeit</German>
+            <Polish>Szansa na panikę</Polish>
+            <Russian>Шанс паники</Russian>
+        </Key>
+        <Key ID="STR_Lambs_Danger_Settings_PanicChance_ToolTip">
+            <English>Chance to panic in percentage</English>
+            <German>Die Wahrscheinlichkeit in Panik zu verfallen in Prozent.</German>
+            <Polish>Szansa, że jednostka spanikuje, wyrażona w procentach</Polish>
+            <Russian>Шанс паники в процентах</Russian>
+        </Key>
     </Package>
 </Project>


### PR DESCRIPTION
### When merged this pull request will:
This pull request moves the panic feature from the brain to the eventhandler. This has the benefit of simplifying the FSM and making the panic feature more dependable.

The panic feature will not trigger for units that have a positive morale score, are not suppressed, or have their AI forced in some way. The panic feature is enhanced by reintroducing the panic types existant in lambs danger fsm 2.4.4

Answers to issue: https://github.com/nk3nny/LambsDanger/issues/212
