### PR TITLE
Fix doSelectWarhead errors

### DIFF
--- a/addons/danger/functions/fnc_brainVehicle.sqf
+++ b/addons/danger/functions/fnc_brainVehicle.sqf
@@ -95,13 +95,16 @@ if (_attack && {RND(0.6)}) then {[_unit, _dangerCausedBy] call EFUNC(main,doShar
 if (_attack && {!EGVAR(main,disableAutonomousMunitionSwitching) && {!(isNull _dangerCausedBy) && {
     (_vehicle getVariable [QGVAR(warheadSwitchTimeout), -1]) < CBA_missionTime}}}) then {
     _vehicle setVariable [QGVAR(warheadSwitchTimeout), CBA_missionTime + 15];
-    private _enemyVic = vehicle _dangerCausedBy;
-    if (_enemyVic isKindOf "Tank" || {
-        _enemyVic isKindOf "Wheeled_APC_F"}) then {
-        [_vehicle, ["AP", "TANDEMHEAT"], true] call EFUNC(main,doSelectWarhead);
-    } else {
-        [_vehicle] call EFUNC(main,doSelectWarhead);
-    };
+    [{
+        params ["_vehicle", "_dangerCausedBy"];
+        private _enemyVic = vehicle _dangerCausedBy;
+        if (_enemyVic isKindOf "Tank" || {
+            _enemyVic isKindOf "Wheeled_APC_F"}) then {
+            [_vehicle, ["AP", "TANDEMHEAT"], true] call EFUNC(main,doSelectWarhead);
+        } else {
+            [_vehicle] call EFUNC(main,doSelectWarhead);
+        };
+    }, [_vehicle, _dangerCausedBy]] call CBA_fnc_directCall;
 };
 
 // vehicle type ~ Armoured vehicle

--- a/addons/main/functions/VehicleAction/fnc_doSelectWarhead.sqf
+++ b/addons/main/functions/VehicleAction/fnc_doSelectWarhead.sqf
@@ -22,11 +22,17 @@ params ["_vehicle", ["_warheadTypes", ["HE", "HEAT"]], ["_switchMuzzle", false]]
 private _gunner = gunner _vehicle;
 if (isNull _gunner) exitWith {false};
 
+private _assignedRoles = assignedVehicleRole _gunner;
+// is either assigned nothing, driving or a cargo role without turret path
+if ((count _assignedRoles) < 2) exitWith {false};
+
 // figure out turret and ammo
-private _turretPath = (assignedVehicleRole _gunner) select 1;
+private _turretPath = _assignedRoles select 1;
 private _turretMagazines = _vehicle magazinesTurret _turretPath;
 private _vehicleMagazines = magazines [_vehicle, false];
 private _turrets = _vehicle weaponsTurret _turretPath;
+
+if (isNil "_turrets") exitWith {false};
 
 // kick out magazines that do not belong to the gunner turrets
 private _availableMags = _turretMagazines arrayIntersect _vehicleMagazines;

--- a/addons/main/functions/VehicleAction/fnc_doSelectWarhead.sqf
+++ b/addons/main/functions/VehicleAction/fnc_doSelectWarhead.sqf
@@ -74,8 +74,9 @@ if (_muzzle isEqualTo "") then {
             {
                 private _ammo = getText (configFile >> "CfgMagazines" >> _x >> "ammo");
                 if (_ammo isEqualTo "") then {continue};
-                if ((toUpper (getText (configFile >> "CfgAmmo" >> _ammo >> "warheadName"))) in _warheadTypes) exitWith {
+                if ((toUpper (getText (configFile >> "CfgAmmo" >> _ammo >> "warheadName"))) in _warheadTypes) then {
                     _foundMag = _x;
+                    break;
                 };
             } forEach _magazines;
             _foundMag isNotEqualTo ""


### PR DESCRIPTION
Fix doSelectWarhead error when vehicle role is not a gunner with a turret path

### When merged this pull request will:

1. Add some more checks before going through each turret

possible fix for #266 
