### PR TITLE
Improve vehicle brain by adding Air category and improving suppression

### DIFF
--- a/addons/danger/functions/fnc_brainVehicle.sqf
+++ b/addons/danger/functions/fnc_brainVehicle.sqf
@@ -69,6 +69,11 @@ if (_artillery) exitWith {
 // variable
 _vehicle setVariable [QEGVAR(main,isArtillery), false];
 
+// vehicle type ~ Air
+if (_vehicle isKindOf "Air") exitWith {
+    [_timeout + 2 + random 2] + _causeArray
+};
+
 // vehicle type ~ Static weapon
 private _static = _vehicle isKindOf "StaticWeapon";
 if (_static) exitWith {
@@ -90,8 +95,9 @@ if (_static) exitWith {
 };
 
 // update information
-if (_attack && {RND(0.6)}) then {[_unit, _dangerCausedBy] call EFUNC(main,doShareInformation);};
+if (_cause isEqualTo DANGER_ENEMYNEAR) then {[_unit, _dangerCausedBy] call EFUNC(main,doShareInformation);};
 
+// select turret ammunition
 if (_attack && {!EGVAR(main,disableAutonomousMunitionSwitching) && {!(isNull _dangerCausedBy) && {
     (_vehicle getVariable [QGVAR(warheadSwitchTimeout), -1]) < CBA_missionTime}}}) then {
     _vehicle setVariable [QGVAR(warheadSwitchTimeout), CBA_missionTime + 15];
@@ -109,7 +115,7 @@ private _armored = _vehicle isKindOf "Tank" || {_vehicle isKindOf "Wheeled_APC_F
 if (_armored && {!isNull _dangerCausedBy}) exitWith {
 
     // delay + info
-    private _delay = 2 + random 2;
+    private _delay = 2 + random 3;
 
     // vehicle jink
     private _oldDamage = _vehicle getVariable [QGVAR(vehicleDamage), 0];
@@ -122,7 +128,7 @@ if (_armored && {!isNull _dangerCausedBy}) exitWith {
 
     // tank assault
     if (_attack && {speed _vehicle < 20}) then {
-        // rotate + suppression (internal to vehicle rotate)
+        // rotate
         [_vehicle, _dangerCausedBy] call EFUNC(main,doVehicleRotate);
 
         // assault

--- a/addons/main/functions/VehicleAction/fnc_doVehicleAssault.sqf
+++ b/addons/main/functions/VehicleAction/fnc_doVehicleAssault.sqf
@@ -35,18 +35,18 @@ private _predictedPos = _unit getHideFrom _target;
 if (_predictedPos isEqualTo [0, 0, 0]) exitWith {false};
 
 // define buildings
-private _visibility = [objNull, "VIEW", _vehicle] checkVisibility [eyePos _vehicle, ATLtoASL (_predictedPos vectorAdd [0, 0, 1 + random 1])];
+private _visibility = [objNull, "VIEW", _vehicle] checkVisibility [eyePos _vehicle, ATLtoASL (_predictedPos vectorAdd [0, 0, 1.5])];
 if (_buildings isEqualTo [] && {_visibility < 0.5}) then {
     _buildings = [_target, 12, false, false] call FUNC(findBuildings);
 };
 
-// find closest building
+// get building positions
 if (_buildings isNotEqualTo []) then {
     _buildings = (selectRandom _buildings) buildingPos -1;
 };
 
 // add predicted location -- just to ensure shots fired!
-_buildings pushBack _predictedPos;
+if (_buildings isEqualTo []) then {_buildings pushBack _predictedPos;};
 
 // pos
 _pos = selectRandom _buildings;
@@ -84,7 +84,7 @@ if (_cannon) then {
 // debug
 if (GVAR(debug_functions)) then {
     [
-        "%1 Vehicle assault building (%2 @ %3 buildingPos %4 %5)",
+        "%1 Vehicle assault building (%2 @ %3 positions%4%5)",
         side _unit,
         getText (configOf _vehicle >> "displayName"),
         count _buildings,

--- a/addons/main/functions/VehicleAction/fnc_doVehicleRotate.sqf
+++ b/addons/main/functions/VehicleAction/fnc_doVehicleRotate.sqf
@@ -40,10 +40,6 @@ _unit setVariable [QGVAR(currentTask), "Vehicle Rotate", GVAR(debug_functions)];
 
 // within acceptble limits -- suppress instead
 if (_unit getRelDir _target < _threshold || {_unit getRelDir _target > (360-_threshold)}) exitWith {
-    private _enemy = _unit findNearestEnemy _target;
-    if (!isNull _enemy && {_unit distance2D _enemy < 600}) then {
-        [_unit, _unit getHideFrom _enemy] call FUNC(doVehicleSuppress);
-    };
     true
 };
 


### PR DESCRIPTION
### Improves vehicle brain
- Adds check for Air vehicle category
- Fixes duplicate suppression via. vehicleRotate
- Fixes vehicles spamming shareInformation
- Changes suppression timing randomisation somewhat to allow for slightly greater suppression intervals

**Logic**: 
1. Stops doVehicleRotate from calling suppression. That is better done via. doVehicleAssault which will happen 2 seconds later. This prevents suppression spam and also makes doVehicleRotate a more useful _generic_ function.

2. Changing doShareInformation to only happen on _first_ enemy contact greatly reduces spam (especially bad considering the long range of vehicle communication.

3. Air vehicles are prevented from communicating enemy locations by design. Air vehicles tend to confuse themselves (and crash or get stunned) enough as is.

4. doVehicleAssault will now only add _predictedPos when no buildings are found. This reduces instances of vehicles shooting into air.