### PR TITLE
Fix Zen Action for TaskPatrol calling wrong Event

### DIFF
--- a/addons/wp/functions/ZEN/fnc_setPatrol.sqf
+++ b/addons/wp/functions/ZEN/fnc_setPatrol.sqf
@@ -5,5 +5,5 @@ GET_GROUPS_CONTEXT(_targets);
 
 {
     private _leader = leader _x;
-    [QFUNC(taskPatrol), [_x, getPos _leader], _leader] call CBA_fnc_targetEvent;
+    [QGVAR(taskPatrol), [_x, getPos _leader], _leader] call CBA_fnc_targetEvent;
 } forEach _targets;


### PR DESCRIPTION
### When merged this pull request will:

1. *Title*
