### PR TITLE
implement smoke grenade usage as a config option

### DIFF
--- a/addons/danger/functions/fnc_tacticsAssault.sqf
+++ b/addons/danger/functions/fnc_tacticsAssault.sqf
@@ -77,7 +77,7 @@ _group enableAttack false;
 [_unit, "combat", "Advance", 125] call EFUNC(main,doCallout);
 
 // concealment
-if (_unit distance2D _target > 25) then {
+if (!QGVAR(disableAutonomousSmokeGrenades) && _unit distance2D _target > 25) then {
 
     // leader smoke
     if ((getSuppression _unit) isNotEqualTo 0) then {[_unit, _target] call EFUNC(main,doSmoke);};

--- a/addons/danger/functions/fnc_tacticsAssault.sqf
+++ b/addons/danger/functions/fnc_tacticsAssault.sqf
@@ -77,7 +77,7 @@ _group enableAttack false;
 [_unit, "combat", "Advance", 125] call EFUNC(main,doCallout);
 
 // concealment
-if (!QGVAR(disableAutonomousSmokeGrenades) && _unit distance2D _target > 25) then {
+if (!GVAR(disableAutonomousSmokeGrenades) && _unit distance2D _target > 25) then {
 
     // leader smoke
     if ((getSuppression _unit) isNotEqualTo 0) then {[_unit, _target] call EFUNC(main,doSmoke);};

--- a/addons/danger/functions/fnc_tacticsAssault.sqf
+++ b/addons/danger/functions/fnc_tacticsAssault.sqf
@@ -77,7 +77,7 @@ _group enableAttack false;
 [_unit, "combat", "Advance", 125] call EFUNC(main,doCallout);
 
 // concealment
-if (!GVAR(disableAutonomousSmokeGrenades) && _unit distance2D _target > 25) then {
+if (!GVAR(disableAutonomousSmokeGrenades) && {_unit distance2D _target > 25}) then {
 
     // leader smoke
     if ((getSuppression _unit) isNotEqualTo 0) then {[_unit, _target] call EFUNC(main,doSmoke);};

--- a/addons/danger/functions/fnc_tacticsAssess.sqf
+++ b/addons/danger/functions/fnc_tacticsAssess.sqf
@@ -162,7 +162,7 @@ if !(_enemies isEqualTo [] || {_unitCount < random 3}) then {
         if ((nearestTerrainObjects [ _unit, ["BUSH", "TREE", "HOUSE", "HIDE"], 4, false, true ]) isEqualTo []) then {_plan pushBack TACTICS_FLANK;};
 
         // conceal movement
-        if (!QGVAR(disableAutonomousSmokeGrenades) && (getSuppression _unit) isNotEqualTo 0) then {[_unit, _pos] call EFUNC(main,doSmoke);};
+        if (!GVAR(disableAutonomousSmokeGrenades) && (getSuppression _unit) isNotEqualTo 0) then {[_unit, _pos] call EFUNC(main,doSmoke);};
     };
 };
 

--- a/addons/danger/functions/fnc_tacticsAssess.sqf
+++ b/addons/danger/functions/fnc_tacticsAssess.sqf
@@ -162,7 +162,7 @@ if !(_enemies isEqualTo [] || {_unitCount < random 3}) then {
         if ((nearestTerrainObjects [ _unit, ["BUSH", "TREE", "HOUSE", "HIDE"], 4, false, true ]) isEqualTo []) then {_plan pushBack TACTICS_FLANK;};
 
         // conceal movement
-        if ((getSuppression _unit) isNotEqualTo 0) then {[_unit, _pos] call EFUNC(main,doSmoke);};
+        if (!QGVAR(disableAutonomousSmokeGrenades) && (getSuppression _unit) isNotEqualTo 0) then {[_unit, _pos] call EFUNC(main,doSmoke);};
     };
 };
 

--- a/addons/danger/functions/fnc_tacticsAssess.sqf
+++ b/addons/danger/functions/fnc_tacticsAssess.sqf
@@ -162,7 +162,7 @@ if !(_enemies isEqualTo [] || {_unitCount < random 3}) then {
         if ((nearestTerrainObjects [ _unit, ["BUSH", "TREE", "HOUSE", "HIDE"], 4, false, true ]) isEqualTo []) then {_plan pushBack TACTICS_FLANK;};
 
         // conceal movement
-        if (!GVAR(disableAutonomousSmokeGrenades) && (getSuppression _unit) isNotEqualTo 0) then {[_unit, _pos] call EFUNC(main,doSmoke);};
+        if (!GVAR(disableAutonomousSmokeGrenades) && {(getSuppression _unit) isNotEqualTo 0}) then {[_unit, _pos] call EFUNC(main,doSmoke);};
     };
 };
 

--- a/addons/danger/functions/fnc_tacticsFlank.sqf
+++ b/addons/danger/functions/fnc_tacticsFlank.sqf
@@ -108,7 +108,7 @@ _units commandMove _overwatch;
 } foreach _units;
 
 // leader smoke ~ deploy concealment to enable movement
-if (!GVAR(disableAutonomousSmoke) && (getSuppression _unit) isNotEqualTo 0) then {[_unit, _overwatch] call EFUNC(main,doSmoke);};
+if (!GVAR(disableAutonomousSmoke) && {(getSuppression _unit) isNotEqualTo 0}) then {[_unit, _overwatch] call EFUNC(main,doSmoke);};
 
 // function
 [{_this call EFUNC(main,doGroupFlank)}, [_cycle, _units, _vehicles, _pos, _overwatch], 2 + random 8] call CBA_fnc_waitAndExecute;

--- a/addons/danger/functions/fnc_tacticsFlank.sqf
+++ b/addons/danger/functions/fnc_tacticsFlank.sqf
@@ -108,7 +108,7 @@ _units commandMove _overwatch;
 } foreach _units;
 
 // leader smoke ~ deploy concealment to enable movement
-if (!QGVAR(disableAutonomousSmoke) && (getSuppression _unit) isNotEqualTo 0) then {[_unit, _overwatch] call EFUNC(main,doSmoke);};
+if (!GVAR(disableAutonomousSmoke) && (getSuppression _unit) isNotEqualTo 0) then {[_unit, _overwatch] call EFUNC(main,doSmoke);};
 
 // function
 [{_this call EFUNC(main,doGroupFlank)}, [_cycle, _units, _vehicles, _pos, _overwatch], 2 + random 8] call CBA_fnc_waitAndExecute;

--- a/addons/danger/functions/fnc_tacticsFlank.sqf
+++ b/addons/danger/functions/fnc_tacticsFlank.sqf
@@ -108,7 +108,7 @@ _units commandMove _overwatch;
 } foreach _units;
 
 // leader smoke ~ deploy concealment to enable movement
-if ((getSuppression _unit) isNotEqualTo 0) then {[_unit, _overwatch] call EFUNC(main,doSmoke);};
+if (!QGVAR(disableAutonomousSmoke) && (getSuppression _unit) isNotEqualTo 0) then {[_unit, _overwatch] call EFUNC(main,doSmoke);};
 
 // function
 [{_this call EFUNC(main,doGroupFlank)}, [_cycle, _units, _vehicles, _pos, _overwatch], 2 + random 8] call CBA_fnc_waitAndExecute;

--- a/addons/danger/settings.sqf
+++ b/addons/danger/settings.sqf
@@ -62,8 +62,6 @@ private _curCat = ELSTRING(main,Settings_MainCat);
     0
 ] call CBA_fnc_addSetting;
 
-/*
-APPARENTLY UNUSED?
 
 // Toggles units self-use of smoke grenades for cover
 [
@@ -74,7 +72,6 @@ APPARENTLY UNUSED?
     false,
     0
 ] call CBA_fnc_addSetting;
-*/
 
 
 // Toggles units self-use of flares for illumation


### PR DESCRIPTION
### When merged this pull request will:

1. Re-add the smoke grenade usage config option
2. Prevent AI from using smoke grenades if the CBA option is checked

I put the check before doSmoke is called, unsure if it would be better to just do one check after doSmoke is called versus preventing doSmoke from being called if the check doesn't pass, easy to change regardless so let me know which one would be better
