### PR TITLE
Fix: Prevents units from failing to forget their previous attack target

### DIFF
--- a/addons/danger/functions/fnc_brainForced.sqf
+++ b/addons/danger/functions/fnc_brainForced.sqf
@@ -42,7 +42,10 @@ if (fleeing _unit) exitWith {
 // attack speed and stance
 if ((currentCommand _unit) isEqualTo "ATTACK") then {
     private _attackTarget = getAttackTarget _unit;
-    if ((typeOf _attackTarget) isEqualTo "SuppressTarget") exitWith {deleteVehicle _attackTarget;};
+    if ((typeOf _attackTarget) isEqualTo "SuppressTarget") exitWith {
+        deleteVehicle _attackTarget;
+        _unit doWatch objNull;
+    };
     [_unit, _attackTarget] call EFUNC(main,doAssaultSpeed);
     _unit setUnitPosWeak (["MIDDLE", "PRONE"] select (getSuppression _unit > 0.9));
     _unit setVariable [QEGVAR(main,currentTask), "Attacking", EGVAR(main,debug_functions)];


### PR DESCRIPTION
Occasionally units will get "locked in" to attacking allied suppressTargets -- this results in the unit failing to move.

Deleting the target _and_ doWatch objNull fixes it.