### PR TITLE
Fix combat mode errors

### DIFF
--- a/addons/danger/XEH_preInit.sqf
+++ b/addons/danger/XEH_preInit.sqf
@@ -42,12 +42,12 @@ if (isNil QGVAR(dangerUntil)) then {
             };
 
             // set combatMode
-            if !(_leader distance2D _unit > (EGVAR(main,combatShareRange)) && {_leader getVariable [QGVAR(disableAI), false]}) then {
-                _x setBehaviour "COMBAT";
+            if (_leader distance2D _unit < (EGVAR(main,combatShareRange)) && {!(_leader getVariable [QGVAR(disableAI), false])} && {(behaviour _leader) isNotEqualTo "COMBAT"}) then {
+                [units _x, _target, [_leader, 40, true, true] call EFUNC(main,findBuildings), "information"] call EFUNC(main,doGroupHide);
                 _x setFormDir (_leader getDir _unit);
             };
         };
-    } forEach _groups;
+    } forEach (_groups select {(side _group) isEqualTo (side _unit)});
 }] call CBA_fnc_addEventHandler;
 
 ADDON = true;

--- a/addons/danger/XEH_preInit.sqf
+++ b/addons/danger/XEH_preInit.sqf
@@ -47,7 +47,7 @@ if (isNil QGVAR(dangerUntil)) then {
                 _x setFormDir (_leader getDir _unit);
             };
         };
-    } forEach (_groups select {(side _group) isEqualTo (side _unit)});
+    } forEach (_groups select {(side _x) isEqualTo (side _unit)});
 }] call CBA_fnc_addEventHandler;
 
 ADDON = true;

--- a/addons/danger/functions/fnc_brain.sqf
+++ b/addons/danger/functions/fnc_brain.sqf
@@ -88,7 +88,7 @@ if (_dangerCause isEqualTo DANGER_ASSESS) exitWith {
 
 // immediate actions
 if (_dangerCause in [DANGER_HIT, DANGER_BULLETCLOSE, DANGER_EXPLOSION, DANGER_FIRE]) exitWith {
-    _return set [ACTION_IMMEDIATE, true];
+    _return set [ACTION_IMMEDIATE, (side _group) isNotEqualTo side (group _dangerCausedBy)];
     _return
 };
 

--- a/addons/danger/functions/fnc_tacticsContact.sqf
+++ b/addons/danger/functions/fnc_tacticsContact.sqf
@@ -105,7 +105,6 @@ if (
 _unit setVariable [QEGVAR(main,currentTask), "Tactics Contact", EGVAR(main,debug_functions)];
 
 // set combat behaviour and focus team
-if ((behaviour _unit) isEqualTo "AWARE" && {!isPlayer (leader _group)}) then {_unit setBehaviour "COMBAT";};
 if (!isNull _enemy && {_unit knowsAbout _enemy > 1}) then {_units doWatch _enemy;};
 
 // immediate action -- leaders near to enemy go aggressive!

--- a/addons/danger/functions/fnc_tacticsGarrison.sqf
+++ b/addons/danger/functions/fnc_tacticsGarrison.sqf
@@ -45,7 +45,6 @@ private _group = group _unit;
 if !(_unit call EFUNC(main,isAlive)) exitWith {false};
 
 // set speed and enableAttack
-_group setBehaviour "COMBAT";
 _group setFormation "FILE";
 _group enableAttack false;
 

--- a/addons/danger/functions/fnc_tacticsHide.sqf
+++ b/addons/danger/functions/fnc_tacticsHide.sqf
@@ -49,7 +49,6 @@ private _group = group _unit;
 if !(_unit call EFUNC(main,isAlive)) exitWith {false};
 
 // hold-fire combat mode
-_unit setBehaviour "COMBAT";
 _group setFormation "DIAMOND";
 _group setCombatMode "GREEN";
 _group enableAttack false;

--- a/addons/danger/functions/fnc_tacticsHold.sqf
+++ b/addons/danger/functions/fnc_tacticsHold.sqf
@@ -64,9 +64,6 @@ if (count _units > 2) then {
             // set group task
             _group setVariable [QEGVAR(main,currentTactic), "Holding!", EGVAR(main,debug_functions)];
 
-            // set behaviour
-            _group setBehaviour "COMBAT";
-
             // get buildings and dangerPos
             private _buildings = [leader _unit, 30, true, true] call EFUNC(main,findBuildings);
 

--- a/addons/danger/functions/fnc_tacticsReinforce.sqf
+++ b/addons/danger/functions/fnc_tacticsReinforce.sqf
@@ -84,7 +84,6 @@ if (_distance > 500) then {
         _unit setFormation selectRandom ["WEDGE", "VEE", "LINE"];
     };
     if (_distance < GVAR(cqbRange)) then {
-        _unit setBehaviour "COMBAT";
         _unit setFormation "FILE";
         [_unit, _target] call FUNC(tacticsAssault);
     };


### PR DESCRIPTION
Fixes units becoming stuck in combat mode
Fixes units being triggered to enter combat/contact mode due to friendly fire

**Implementation**
1. Changes the share information feature to trigger a more directly hiding.
2. Prevents all tactics level actions from setting behaviour
3. Small fix brain.sqf to "FIRE" and other immediate actions to sort friendly units*

*For a small sake of performance I'm not sorting for all friendly sides-- Instead I am focused only on units which are the same _side_ as the shooter.  Especially as it seems like allied sides trigger combat behaviour regardless.

**Changes**
This change will mean that units will be somewhat less immediately responsive to enemy fire -- but on the positive side, they'll actually reset when the threat is dealt with(!). 

I also suspect this will fix some issues with transported troops dismounting at early times from transport vehicles.  (i.e., they were sharing information with their drivers-- which triggered combat mode-- which triggered the driver to give the transported units combat mode-- which triggered them jumping out... 

Yeah. 


