### PR TITLE
Adds fleeing info to debug draw banner

### DIFF
--- a/addons/main/functions/debug/fnc_debugDraw.sqf
+++ b/addons/main/functions/debug/fnc_debugDraw.sqf
@@ -219,6 +219,9 @@ private _posCam = positionCameraToWorld [0, 0, 0];
         if (_unit getVariable [QEGVAR(danger,forceMove), false]) then {
             _textData append ["<t color='#ff4000'>Forced AI</t>", "<br/>"];
         };
+        if (fleeing _unit) then {
+            _textData append ["<t color='#FFC0CB'>Fleeing</t>", "<br/>"];
+        };
         [_renderPos, _textData] call _fnc_debug_drawRect;
 
         if (GVAR(debug_RenderExpectedDestination)) then {


### PR DESCRIPTION
Improves utility of debugDraw by showing when units are fleeing.