### PR TITLE
Fix taskCamp forcing animations on units in vehicles

### DIFF
--- a/addons/wp/functions/fnc_taskCamp.sqf
+++ b/addons/wp/functions/fnc_taskCamp.sqf
@@ -223,7 +223,7 @@ _wp setWaypointStatements ["true", "
         {
             _x enableAI 'ANIM';
             _x enableAI 'PATH';
-            [_x, '', 2] call lambs_main_fnc_doAnimation;
+            if (isNull objectParent _x) then {[_x, '', 2] call lambs_main_fnc_doAnimation;};
         } foreach thisList;
     };"
 ];


### PR DESCRIPTION
Prevents taskCamp sentry wp from resetting animations on units that are mounted. Especially loaded in turrets!  OLD BUG!