### PR TITLE
Improve doGroupHide and tacticsContact timings

### DIFF
--- a/addons/danger/functions/fnc_tacticsContact.sqf
+++ b/addons/danger/functions/fnc_tacticsContact.sqf
@@ -113,7 +113,7 @@ if (
     _count > random 3
     && {_unit knowsAbout _enemy > 0.1}
     && {_deadOrSuppressed isEqualTo -1}
-    && {_unit distance2D _enemy < 120}
+    && {_unit distance2D _enemy < GVAR(cqbRange)}
 ) exitWith {
     // execute assault
     {
@@ -131,7 +131,7 @@ if (
 };
 
 // get buildings
-private _buildings = [leader _unit, 30, true, true] call EFUNC(main,findBuildings);
+private _buildings = [leader _unit, 35, true, true] call EFUNC(main,findBuildings);
 
 // immediate action -- leaders further away get their subordinates to hide!
 [_units, _enemy, _buildings, "contact"] call EFUNC(main,doGroupHide);

--- a/addons/main/functions/GroupAction/fnc_doGroupHide.sqf
+++ b/addons/main/functions/GroupAction/fnc_doGroupHide.sqf
@@ -26,7 +26,7 @@ if (_units isEqualTo []) exitWith {false};
 {
     // force movement!
     _x setVariable [QEGVAR(danger,forceMove), true];
-    [{_this setVariable [QEGVAR(danger,forceMove), nil]}, _x, 3.5 + random 5] call CBA_fnc_waitAndExecute;
+    [{_this setVariable [QEGVAR(danger,forceMove), nil]}, _x, 5 + random 11] call CBA_fnc_waitAndExecute;
 
     // hide units
     [


### PR DESCRIPTION
This pull request is focused on tacticsContact and doGroupHide timings and distances.  Increased time and distance for building checks makes the state more dependable and more noticeable.
- Increases the time units may be locked in a AI forced state.
- Changed to use CQB range for close check in contact