### PR TITLE
Improve AI dodging evaluation

### DIFF
--- a/addons/danger/functions/fnc_brain.sqf
+++ b/addons/danger/functions/fnc_brain.sqf
@@ -87,7 +87,7 @@ if (_dangerCause isEqualTo DANGER_ASSESS) exitWith {
 };
 
 // immediate actions
-if (_dangerCause in [DANGER_HIT, DANGER_BULLETCLOSE, DANGER_EXPLOSION, DANGER_FIRE]) exitWith {
+if (_dangerCause in [DANGER_HIT, DANGER_BULLETCLOSE, DANGER_EXPLOSION, DANGER_FIRE] && {getSuppression _unit < 0.9}) exitWith {
     _return set [ACTION_IMMEDIATE, (side _group) isNotEqualTo side (group _dangerCausedBy)];
     _return
 };


### PR DESCRIPTION
Fixes units getting stuck in endless dodging patterns.  The change is simple: units that are "highly suppressed" simply stop dodging.  They are already quite combat ineffective, and usually busy getting shot to pieces anyhow!