### PR TITLE
Improve assault memory and engagement routines

### DIFF
--- a/addons/danger/functions/fnc_brainAssess.sqf
+++ b/addons/danger/functions/fnc_brainAssess.sqf
@@ -31,40 +31,19 @@ private _timeout = time + 2;
 // check if stopped
 if (!(_unit checkAIFeature "PATH")) exitWith {_timeout};
 
-// assigned target
-private _assignedTarget = assignedTarget _unit;
-if (
-    !isNull _assignedTarget
-    && {_unit distance2D _assignedTarget < GVAR(cqbRange)}
-    && {(_unit knowsAbout _assignedTarget) isNotEqualTo 0}
-) exitWith {
-    [_unit, _assignedTarget] call EFUNC(main,doAssault);
-    _timeout + 2
-};
-
 // group memory
 private _groupMemory = (group _unit) getVariable [QEGVAR(main,groupMemory), []];
 
 // sympathetic CQB/suppressive fire
 if (_groupMemory isNotEqualTo []) exitWith {
     [_unit, _groupMemory] call EFUNC(main,doAssaultMemory);
-    _timeout + 2
+    _timeout + 3
 };
-
-// stance
-private _stance = stance _unit;
-if (_stance isEqualTo "STAND") then {_unit setUnitPosWeak "MIDDLE";};
-if (getSuppression _unit > 0.9 && {_stance isEqualTo "CROUCH"}) then {_unit setUnitPosWeak "DOWN";};
 
 // building
 if (RND(EGVAR(main,indoorMove)) && {_unit call EFUNC(main,isIndoor)}) exitWith {
     [_unit, _target] call EFUNC(main,doReposition);
-    _timeout + 1
-};
-
-// cover
-if ((speed _unit) isEqualTo 0 && {_unit distance2D (leader _unit) < 40}) then {
-    [_unit] call EFUNC(main,doCover);
+    _timeout + 2
 };
 
 // end

--- a/addons/danger/functions/fnc_brainEngage.sqf
+++ b/addons/danger/functions/fnc_brainEngage.sqf
@@ -29,13 +29,11 @@ params ["_unit", ["_type", -1], ["_target", objNull]];
 // timeout
 private _timeout = time + 0.5;
 
-// ACE3
-_unit setVariable ["ace_medical_ai_lastFired", CBA_missionTime];
-
 // check
 if (
     isNull _target
     || {_unit knowsAbout _target isEqualTo 0}
+    || {(speed _target) > 20}
     || {(weapons _unit) isEqualTo []}
     || {(combatMode _unit) in ["BLUE", "GREEN"]}
 ) exitWith {
@@ -57,19 +55,18 @@ if (
     && {(vehicle _target) isKindOf "CAManBase"}
     && {_target call EFUNC(main,isAlive)}
 ) exitWith {
+    _unit setVariable ["ace_medical_ai_lastFired", CBA_missionTime]; // ACE3
     [_unit, _target] call EFUNC(main,doAssault);
-    _timeout + 4
+    _timeout + 1.5
 };
-
-// set speed
-_unit forceSpeed ([-1, 1] select (_type isEqualTo DANGER_CANFIRE));
 
 // far, try to suppress
 if (
     _distance < 500
     && {RND(getSuppression _unit)}
-    && {_type isEqualTo DANGER_CANFIRE || {RND(0.6) && {_type isEqualTo DANGER_ENEMYDETECTED}}}
+    && {_type isEqualTo DANGER_CANFIRE || {RND(0.4) && {_type isEqualTo DANGER_ENEMYDETECTED}}}
 ) exitWith {
+    _unit forceSpeed 0;
     [_unit, ATLtoASL ((_unit getHideFrom _target) vectorAdd [0, 0, 0.8]), true] call EFUNC(main,doSuppress);
     _timeout + 4
 };

--- a/addons/main/functions/UnitAction/fnc_doAssault.sqf
+++ b/addons/main/functions/UnitAction/fnc_doAssault.sqf
@@ -26,7 +26,7 @@ _unit setVariable [QGVAR(currentTask), "Assault", GVAR(debug_functions)];
 
 // Near buildings + sort near positions + add target actual location
 private _buildings = [_target, _range, true, false] call FUNC(findBuildings);
-_buildings = _buildings select { _x distance _target < 5 };
+_buildings = _buildings select { _x distance _target < 7 };
 
 // set destination
 private _pos = if (_buildings isEqualTo []) then {
@@ -41,24 +41,28 @@ private _pos = if (_buildings isEqualTo []) then {
 } else {
 
     // updates group memory variable
-    private _group = group _unit;
-    private _groupMemory = _group getVariable [QGVAR(groupMemory), []];
-    _groupMemory pushBackUnique selectRandom _buildings;
-    _group setVariable [QGVAR(groupMemory), _groupMemory];
+    if (_unit distance2D _target < 40) then {
+        private _group = group _unit;
+        private _groupMemory = _group getVariable [QGVAR(groupMemory), []];
+        if (_groupMemory isEqualTo []) then {
+            _group setVariable [QGVAR(groupMemory), _buildings];
+        };
+    };
 
     // add unit position to array
     _buildings pushBack (getPosATL _target);
 
     // select building position
-    selectRandom _buildings
+    (selectRandom _buildings) vectorAdd [-1 + random 2, -1 + random 2, 0]
 };
 
 // stance and speed
 [_unit, _pos] call FUNC(doAssaultSpeed);
+_unit setUnitPosWeak (["UP", "MIDDLE"] select (getSuppression _unit > 0.8));
 
 // execute
 _unit doMove _pos;
-_unit setDestination [_pos, "LEADER PLANNED", true];
+_unit setDestination [_pos, "LEADER PLANNED", false];
 
 // debug
 if (GVAR(debug_functions)) then {

--- a/addons/main/functions/UnitAction/fnc_doAssaultMemory.sqf
+++ b/addons/main/functions/UnitAction/fnc_doAssaultMemory.sqf
@@ -27,39 +27,38 @@ if (_groupMemory isEqualTo []) then {
 };
 
 // exit or sort it!
-_groupMemory = _groupMemory select {(leader _unit) distance _x < 200 && {_unit distance _x > 1.5}};
+_groupMemory = _groupMemory select {(leader _unit) distance _x < 150 && {_unit distance _x > 2}};
 if (_groupMemory isEqualTo []) exitWith {
-    _group setVariable [QGVAR(groupMemory), _groupMemory, false];
+    _group setVariable [QGVAR(groupMemory), [], false];
     _unit doFollow (leader _unit);
     false
 };
 
-// leader sorts positions from nearest to furthest
-if ((leader _unit) isEqualTo _unit) then {
-    _groupMemory = _groupMemory apply {[_x distance2D _unit, _x]};
-    _groupMemory sort true;
-    _groupMemory = _groupMemory apply {_x select 1};
-};
+// sort positions from nearest to furthest
+_groupMemory = _groupMemory apply {[_x distance _unit, _x]};
+_groupMemory sort true;
+_groupMemory = _groupMemory apply {_x select 1};
 
-// check
-private _pos = _groupMemory select 0;
+// check for enemy get position
+private _enemy = _unit findNearestEnemy _unit;
+private _pos = [_groupMemory select 0, _enemy] select (_unit distance2D _enemy < 12);
 private _distance2D = _unit distance2D _pos;
 if (_pos isEqualType objNull) then {_pos = getPosATL _pos;};
 
 // look at
-_unit lookAt _pos;
+_unit doWatch _pos;
 
 // ACE3 ~ allows unit to clear buildings with aggression - nkenny
-if (_distance2D < 12) then {_unit setVariable ["ace_medical_ai_lastFired", CBA_missionTime];};
+if (_distance2D < 7) then {_unit setVariable ["ace_medical_ai_lastFired", CBA_missionTime];};
 
-// CQB or suppress
+// CQB
 if (RND(0.9) || {_distance2D < 66}) then {
     // movement
-    _unit forceSpeed 4;
+    _unit setUnitPosWeak "UP";
 
     // execute CQB move
     _unit doMove _pos;
-    _unit setDestination [_pos, "LEADER PLANNED", _distance2D < 15];
+    _unit setDestination [_pos, "LEADER PLANNED", false];
 
     // variables
     _unit setVariable [QGVAR(currentTarget), _pos, GVAR(debug_functions)];
@@ -72,10 +71,13 @@ if (RND(0.9) || {_distance2D < 66}) then {
         _sphere setObjectTexture [0, [_unit] call FUNC(debugObjectColor)];
         [{deleteVehicle _this}, _sphere, 12] call CBA_fnc_waitAndExecute;
     };
+} else {
+    // reset
+    _unit setUnitPosWeak "MIDDLE";
 };
 
 // update variable
-if (RND(0.95) || {_distance2D < 4}) then {_groupMemory deleteAt 0;};
+if (RND(0.9) || {_distance2D < 4}) then {_groupMemory deleteAt 0;};
 _group setVariable [QGVAR(groupMemory), _groupMemory, false];
 
 // end

--- a/addons/main/functions/UnitAction/fnc_doAssaultMemory.sqf
+++ b/addons/main/functions/UnitAction/fnc_doAssaultMemory.sqf
@@ -40,8 +40,7 @@ _groupMemory sort true;
 _groupMemory = _groupMemory apply {_x select 1};
 
 // check for enemy get position
-private _enemy = _unit findNearestEnemy _unit;
-private _pos = [_groupMemory select 0, _enemy] select (_unit distance2D _enemy < 12);
+private _pos = [_groupMemory select 0, _unit findNearestEnemy _unit] select (_unit distance2D (_unit findNearestEnemy _unit) < 12);
 private _distance2D = _unit distance2D _pos;
 if (_pos isEqualType objNull) then {_pos = getPosATL _pos;};
 


### PR DESCRIPTION
This pull request tunes AI close quarter battle ability and introduces small bug fixes.  It does this by tuning behaviours and introducing a change in how groupMemory entries are handled by groups. _See below_.

**brainEngage.sqf**
- Tweaks various brainEngage timings for increased aggression
- Increased chance of suppressing enemyDetected (taking advantage of improved suppress AI added in previous releases)
- Fix Units will only set "ACE_medical_ai_lastFired" when in CQB
- Fix Units will no longer suppress quickly moving vehicles, such as aircraft

**brainAssess.sqf**
- Removes many features from brainAssess which were necessary with the earllier slower brainEngage timings.
- Slimmer and better performing.

**doAssault.sqf**
- Better handling of stance in doAssault. (More standing means more reliable movement)
- Increased building check distance to get more positions. From 5 to 7 meters.
- Improved groupMemory*
- Reintroduce slight randomness to indoor assault locations (prevents units getting stuck)

**doAssaultMemory.sqf**
- Adds distance sorting to nearby positions
- Adds 'break out' routine if threatened by known, nearby enemy.
- Added stance change if nearest location is beyond 66M
- changed from doLook to doWatch for better group focus.
- Changed to Stance tweak and removed speed change to remove staccato movement.

_Improved group Memory_
*Building positions are now only added to groupMemory if the list is currently empty and the calling unit is fairly close (40 meters) to the building in question. This enhancement makes groups more reliable clear building by building-- and prevents the groupMemory from becoming endlessly growing.

The groupMemory feature now also has breakout patterns if the AI is threatened by nearby enemies.  And finally it interacts very well with the tightened timings-- adding an aggressive and constantly searching AI.