### PR TITLE
Improve Garrison group tactics

### DIFF
--- a/tools/sqf_linter_LogChecker.py
+++ b/tools/sqf_linter_LogChecker.py
@@ -1,7 +1,7 @@
 import sys
 import os
 
-defaultFalsePositives = 18
+defaultFalsePositives = 16
 def main():
     f = open("sqf.log", "r")
     log = f.readlines()


### PR DESCRIPTION
Adds better groupMemory handling
Adds use of doWatch to focus group
Tweaks Increased distance check (from 25 to 42 meters) 
Changes buildings now sorted by distance (instead of height)
Removes cover being added to movement locations


More information - see below. 

----

Changes sorting of building locations from by height to distance to leader, which makes movement much more reliable.  It also gets to practically the same situation -- as the group leader generally is on the ground.

Removes Adding nearby cover to building positions. Better handling of building positions is more than enough.

This change affords a tweak to building search range, i.e., increased.  It also allows for  better handling of groupMemory. (Unused positions are added to memory).