### PR TITLE
Improve Assault group tactics

### DIFF
--- a/addons/danger/functions/fnc_tacticsAssault.sqf
+++ b/addons/danger/functions/fnc_tacticsAssault.sqf
@@ -18,7 +18,7 @@
  *
  * Public: No
 */
-params ["_unit", "_target", ["_units", []], ["_cycle", 15], ["_delay", 80]];
+params ["_unit", "_target", ["_units", []], ["_cycle", 11], ["_delay", 90]];
 
 // find target
 _target = _target call CBA_fnc_getPos;
@@ -55,7 +55,10 @@ if (_units isEqualTo []) exitWith {false};
 
 // sort potential targets
 private _buildings = [_target, 8, true, false] call EFUNC(main,findBuildings);
-_buildings append ((_unit targets [true, 10, [], 0, _target]) apply {_unit getHideFrom _x});
+_buildings append ((_unit targets [true, 12, [], 0, _target]) apply {getPosATL _x});
+_buildings = _buildings apply { [_x select 2, _x] };
+_buildings sort false;
+_buildings = _buildings apply { _x select 1 };
 _buildings pushBack _target;
 
 // set tasks
@@ -80,10 +83,10 @@ _group enableAttack false;
 if (!GVAR(disableAutonomousSmokeGrenades) && {_unit distance2D _target > 25}) then {
 
     // leader smoke
-    if ((getSuppression _unit) isNotEqualTo 0) then {[_unit, _target] call EFUNC(main,doSmoke);};
+    [_unit, _target] call EFUNC(main,doSmoke);
 
     // grenadier smoke
-    [{_this call EFUNC(main,doUGL)}, [+_units, _target, "shotSmokeX"], 3] call CBA_fnc_waitAndExecute;
+    [{_this call EFUNC(main,doUGL)}, [_units, _target, "shotSmokeX"], 3] call CBA_fnc_waitAndExecute;
 };
 
 // ready group

--- a/addons/main/functions/GroupAction/fnc_doGroupAssault.sqf
+++ b/addons/main/functions/GroupAction/fnc_doGroupAssault.sqf
@@ -31,8 +31,8 @@ private _targetPos = _pos deleteAt 0;
     _x setVariable [QEGVAR(danger,forceMove), true];
 
     // check enemy
-    private _enemy = _unit findNearestEnemy _unit;
-    if (_unit distance2D _enemy < 12) then {_targetPos = getPosATL _enemy;};
+    private _enemy = _x findNearestEnemy _x;
+    if (_x distance2D _enemy < 12) then {_targetPos = getPosATL _enemy;};
 
     // setpos
     if (RND(0.75) || {(currentCommand _x) isNotEqualTo "MOVE"}) then {

--- a/addons/main/functions/GroupAction/fnc_doGroupAssault.sqf
+++ b/addons/main/functions/GroupAction/fnc_doGroupAssault.sqf
@@ -31,7 +31,8 @@ private _targetPos = _pos deleteAt 0;
     _x setVariable [QEGVAR(danger,forceMove), true];
 
     // check enemy
-    if (_x distance2D (_x findNearestEnemy _x) < 12) then {_targetPos = getPosATL (_x findNearestEnemy _x);};
+    private _enemy = _x findNearestEnemy _x;
+    if (_x distance2D _enemy < 12) then {_targetPos = getPosATL _enemy;};
 
     // setpos
     if (RND(0.75) || {(currentCommand _x) isNotEqualTo "MOVE"}) then {

--- a/addons/main/functions/GroupAction/fnc_doGroupAssault.sqf
+++ b/addons/main/functions/GroupAction/fnc_doGroupAssault.sqf
@@ -31,8 +31,7 @@ private _targetPos = _pos deleteAt 0;
     _x setVariable [QEGVAR(danger,forceMove), true];
 
     // check enemy
-    private _enemy = _x findNearestEnemy _x;
-    if (_x distance2D _enemy < 12) then {_targetPos = getPosATL _enemy;};
+    if (_x distance2D (_x findNearestEnemy _x) < 12) then {_targetPos = getPosATL (_x findNearestEnemy _x);};
 
     // setpos
     if (RND(0.75) || {(currentCommand _x) isNotEqualTo "MOVE"}) then {


### PR DESCRIPTION
This pull request adds a significantly improved assault pattern.  At its core the biggest change are tuned timings and distances, and introducing sorting of building/enemy locations by distance to leader.  This means that the squad will converge on each location in an organised fashion-- where previously they did so more randomly in a shotgun pattern.

_doGroupAssault.sqf_ has been improved with breakout patterns (when an AI is immediately threatened by AI) and a better tuned movement speed-- meaning the units will move with their weapons raised, rather than sprinting. Obviously more conducive to assaulting...