### PR TITLE
Improved tactics assess

### DIFF
--- a/addons/danger/functions/fnc_tacticsAssess.sqf
+++ b/addons/danger/functions/fnc_tacticsAssess.sqf
@@ -33,6 +33,7 @@ private _group = group _unit;
 // set variable
 _group setVariable [QGVAR(isExecutingTactic), true];
 _group setVariable [QGVAR(contact), time + 600];
+_group enableAttack false;
 
 // set current task
 _unit setVariable [QEGVAR(main,currentTarget), objNull, EGVAR(main,debug_functions)];
@@ -53,6 +54,11 @@ private _plan = [];
 // sort plans
 _pos = [];
 if !(_enemies isEqualTo [] || {_unitCount < random 3}) then {
+
+    // sort nearest enemies
+    _enemies = _enemies apply {[_x distance2D _unit, _x]};
+    _enemies sort true;
+    _enemies = _enemies apply {_x select 1};
 
     // get modes
     private _speedMode = (speedMode _unit) isEqualTo "FULL";
@@ -147,7 +153,7 @@ if !(_enemies isEqualTo [] || {_unitCount < random 3}) then {
     if (_fortifiedTarget != -1) exitWith {
 
         // basic plan
-        _plan append [TACTICS_FLANK, TACTICS_FLANK, TACTICS_SUPPRESS];
+        _plan append [TACTICS_FLANK, TACTICS_FLANK];
         _pos = _unit getHideFrom (_enemies select _fortifiedTarget);
 
         // combatmode
@@ -211,10 +217,10 @@ _plan = selectRandom _plan;
 switch (_plan) do {
     case TACTICS_FLANK: {
         // flank
-        [{_this call FUNC(tacticsFlank)}, [_unit, _pos], 22 + random 8] call CBA_fnc_waitAndExecute;
+        [{_this call FUNC(tacticsFlank)}, [_unit, _pos, _units], 22 + random 8] call CBA_fnc_waitAndExecute;
     };
     case TACTICS_GARRISON: {
-        // garrison
+        // garrison ~ nb units not carried here - nkenny
         [{_this call FUNC(tacticsGarrison)}, [_unit, _pos], 10 + random 6] call CBA_fnc_waitAndExecute;
     };
     case TACTICS_ASSAULT: {
@@ -223,15 +229,15 @@ switch (_plan) do {
     };
     case TACTICS_SUPPRESS: {
         // suppress
-        [{_this call FUNC(tacticsSuppress)}, [_unit, _pos], 4 + random 4] call CBA_fnc_waitAndExecute;
+        [{_this call FUNC(tacticsSuppress)}, [_unit, _pos, _units], 4 + random 4] call CBA_fnc_waitAndExecute;
     };
     case TACTICS_ATTACK: {
         // group attacks as one
-        [{_this call FUNC(tacticsAttack)}, [_unit, _pos], random 1] call CBA_fnc_waitAndExecute;
+        [{_this call FUNC(tacticsAttack)}, [_unit, _pos, _units], 1 + random 1] call CBA_fnc_waitAndExecute;
     };
     default {
         // hide from armor
-        [{_this call FUNC(tacticsHide)}, [_unit, _pos, true], random 3] call CBA_fnc_waitAndExecute;
+        [{_this call FUNC(tacticsHide)}, [_unit, _pos, true], 1 + random 3] call CBA_fnc_waitAndExecute;
     };
 };
 

--- a/addons/danger/functions/fnc_tacticsAssess.sqf
+++ b/addons/danger/functions/fnc_tacticsAssess.sqf
@@ -56,7 +56,7 @@ _pos = [];
 if !(_enemies isEqualTo [] || {_unitCount < random 3}) then {
 
     // sort nearest enemies
-    _enemies = _enemies apply {[_x distance2D _unit, _x]};
+    _enemies = _enemies apply {[_x distanceSqr _unit, _x]};
     _enemies sort true;
     _enemies = _enemies apply {_x select 1};
 


### PR DESCRIPTION
- Adds sorting enemies based on distance
- Fixes groups failing to deploy static weapons (and sometimes UGL flares)
- Changed - reverts Suppression chance to accomodate #304
- Removed vanilla attack feature from groups*

*This is a big one which we've talked about internally before. What this does is remove the lock-in units sometimes suffer due to the vanilla ATTACK pattern/fsm.  I propose to check this on the development version.

Our own _group_ level attack patterns are better than the individual vanilla ones. But the AI is a complicated beast. Additional testing should be done.