### PR TITLE
Fix failed to reinsert leader when finding static weapons

### DIFF
--- a/addons/main/functions/GroupAction/fnc_doGroupStaticFind.sqf
+++ b/addons/main/functions/GroupAction/fnc_doGroupStaticFind.sqf
@@ -54,5 +54,8 @@ if !((_weapons isEqualTo []) || (_units isEqualTo [])) then { // De Morgan's law
     (group _unit) addVehicle _weapons;
 };
 
+// reinsert leader
+_units pushBack _unit;
+
 // return
 _units


### PR DESCRIPTION
Unit leaders were removed group _units array but never reinserted. Meaning group actions were always undertaken without group leader!