### PR TITLE
Improvements to Engagement

### DIFF
--- a/addons/danger/functions/fnc_brainAssess.sqf
+++ b/addons/danger/functions/fnc_brainAssess.sqf
@@ -26,7 +26,7 @@
 params ["_unit", "", "", ["_target", objNull]];
 
 // timeout
-private _timeout = time + 2;
+private _timeout = time + 4;
 
 // check if stopped
 if (!(_unit checkAIFeature "PATH")) exitWith {_timeout};
@@ -37,14 +37,18 @@ private _groupMemory = (group _unit) getVariable [QEGVAR(main,groupMemory), []];
 // sympathetic CQB/suppressive fire
 if (_groupMemory isNotEqualTo []) exitWith {
     [_unit, _groupMemory] call EFUNC(main,doAssaultMemory);
-    _timeout + 3
+    _timeout
 };
 
 // building
 if (RND(EGVAR(main,indoorMove)) && {_unit call EFUNC(main,isIndoor)}) exitWith {
     [_unit, _target] call EFUNC(main,doReposition);
-    _timeout + 2
+    _timeout - 1
 };
+
+// reset look
+_unit setUnitPosWeak "MIDDLE";
+_unit doWatch objNull;
 
 // end
 _timeout

--- a/addons/danger/functions/fnc_brainHide.sqf
+++ b/addons/danger/functions/fnc_brainHide.sqf
@@ -21,7 +21,7 @@
     Hide actions
     5 DeadBodyGroup
     6 DeadBody
-    7 Hide
+    7 Scream
     - Panic
 */
 
@@ -37,7 +37,7 @@ if (_type isEqualTo DANGER_SCREAM) exitWith {
     [{_this call EFUNC(main,doShareInformation)}, [_unit, objNull, EGVAR(main,radioShout), true], 2 + random 3] call CBA_fnc_waitAndExecute;
 
     // check danger
-    _unit lookAt _pos;
+    _unit doWatch _pos;
     _unit setVariable [QEGVAR(main,currentTarget), _pos, EGVAR(main,debug_functions)];
     _unit setVariable [QEGVAR(main,currentTask), "Heard scream!", EGVAR(main,debug_functions)];
 
@@ -69,18 +69,13 @@ if (RND(0.05) && {_indoor} && {RND(EGVAR(main,indoorMove))}) exitWith {
 
 // check bodies ~ enemy group!
 if (_type isEqualTo DANGER_DEADBODY) exitWith {
-    private _group = group _unit;
-    private _groupMemory = _group getVariable [QEGVAR(main,groupMemory), []];
 
     // communicate danger!
     [{_this call EFUNC(main,doShareInformation)}, [_unit, objNull, EGVAR(main,radioShout), true], 2 + random 3] call CBA_fnc_waitAndExecute;
 
     // gesture
+    _unit doWatch _pos;
     [_unit, "gestureGoB"] call EFUNC(main,doGesture);
-
-    // add body to move routine
-    _groupMemory pushBack _pos;
-    _group setVariable [QEGVAR(main,groupMemory), _groupMemory, false];
 
     _unit setVariable [QEGVAR(main,currentTarget), _pos, EGVAR(main,debug_functions)];
     _unit setVariable [QEGVAR(main,currentTask), "Checking bodies (unknown)", EGVAR(main,debug_functions)];
@@ -91,7 +86,6 @@ if (_type isEqualTo DANGER_DEADBODY) exitWith {
 
 // drop down into cover
 _unit setUnitPosWeak "DOWN";
-//[_unit, "WalkB", false] call EFUNC(main,doGesture);     May result in soldier phasing into walls - nkenny
 
 // end
 _timeout

--- a/addons/danger/functions/fnc_brainReact.sqf
+++ b/addons/danger/functions/fnc_brainReact.sqf
@@ -33,16 +33,13 @@ private _timeout = time + 1.4;
 // ACE3
 _unit setVariable ["ace_medical_ai_lastHit", CBA_missionTime];
 
-// check it
-_unit lookAt _pos;
-
 // cover move when explosion
 if (
     getSuppression _unit < 0.6
     && {(speed _unit) isEqualTo 0}
     && {_type in [DANGER_EXPLOSION, DANGER_FIRE]}
 ) exitWith {
-    if ((stance _unit) isEqualTo "STAND") then {_unit setUnitPosWeak "MIDDLE";};
+    _unit setUnitPosWeak "DOWN";
     [_unit] call EFUNC(main,doCover);
     _timeout + 1
 };

--- a/addons/danger/scripts/lambs_danger.fsm
+++ b/addons/danger/scripts/lambs_danger.fsm
@@ -24,7 +24,7 @@ item19[] = {"End_Danger",1,250,700.000000,1200.000000,800.000000,1250.000000,0.0
 item20[] = {"no_queue",4,218,700.000000,1075.000000,800.000000,1125.000000,2.000000,"no queue"};
 item21[] = {"timeout",4,218,100.000000,750.000000,200.000000,800.000000,0.000000,"timeout"};
 item22[] = {"timeout",4,218,-250.000000,750.000000,-150.000000,800.000000,0.000000,"timeout"};
-item23[] = {"Reset_foot",2,250,-375.000000,925.000000,275.000000,975.000000,0.000000,"Reset foot"};
+item23[] = {"Reset_foot",2,4346,-375.000000,925.000000,275.000000,975.000000,0.000000,"Reset foot"};
 item24[] = {"true",8,218,500.000000,925.000000,600.000000,975.000000,0.000000,"true"};
 item25[] = {"Check_queue",2,250,700.000000,925.000000,800.000000,975.000000,0.000000,"Check queue"};
 item26[] = {"true",8,218,700.000000,800.000000,800.000000,850.000000,0.000000,"true"};
@@ -108,8 +108,8 @@ link40[] = {35,36};
 link41[] = {36,24};
 link42[] = {37,3};
 link43[] = {38,39};
-globals[] = {0.000000,0,0,0,0,640,480,1,65,6316128,1,-1246.351196,1290.778076,1411.101440,-404.948975,1235,884,1};
-window[] = {2,-1,-1,-1,-1,863,104,1544,104,3,1253};
+globals[] = {0.000000,0,0,0,0,640,480,1,65,6316128,1,-813.988464,339.648987,1448.965088,355.912964,933,884,1};
+window[] = {2,-1,-1,-1,-1,915,156,1596,156,3,951};
 *//*%FSM</HEAD>*/
 class FSM
 {
@@ -356,7 +356,7 @@ class FSM
                          "_timeout = [_this, _dangerCause, _dangerPos] call lambs_danger_fnc_brainReact;" \n
                          "" \n
                          "// re-insert" \n
-                         "_queue pushBack [10, _dangerPos, _dangerUntil + 3, _this findNearestEnemy _this];"/*%FSM</STATEINIT""">*/;
+                         "_queue pushBack [8, _dangerPos, _dangerUntil + 3, _this findNearestEnemy _this];"/*%FSM</STATEINIT""">*/;
                         precondition = /*%FSM<STATEPRECONDITION""">*/""/*%FSM</STATEPRECONDITION""">*/;
                         class Links
                         {
@@ -470,7 +470,7 @@ class FSM
                         name = "Reset_foot";
                         itemno = 23;
                         init = /*%FSM<STATEINIT""">*/"// has living cqb target" \n
-                         "if (_engage && {_dangerCausedBy call lambs_main_fnc_isAlive} && {_this distance2D _dangerCausedBy < 20}) then {" \n
+                         "if (_engage && {_dangerCausedBy call lambs_main_fnc_isAlive} && {_this distance2D _dangerCausedBy < 35}) then {" \n
                          "    _queue pushBack [0, _dangerPos, time + lambs_danger_dangerUntil, _dangerCausedBy];" \n
                          "};" \n
                          "" \n

--- a/addons/main/functions/UnitAction/fnc_doAssaultMemory.sqf
+++ b/addons/main/functions/UnitAction/fnc_doAssaultMemory.sqf
@@ -27,57 +27,71 @@ if (_groupMemory isEqualTo []) then {
 };
 
 // exit or sort it!
-_groupMemory = _groupMemory select {(leader _unit) distance _x < 150 && {_unit distance _x > 2}};
+_groupMemory = _groupMemory select {(leader _unit) distance2D _x < 150 && {_unit distance _x > 1.5}};
 if (_groupMemory isEqualTo []) exitWith {
     _group setVariable [QGVAR(groupMemory), [], false];
-    _unit doFollow (leader _unit);
     false
 };
 
 // sort positions from nearest to furthest
-_groupMemory = _groupMemory apply {[_x distance _unit, _x]};
+_groupMemory = _groupMemory apply {[_x distanceSqr _unit, _x]};
 _groupMemory sort true;
 _groupMemory = _groupMemory apply {_x select 1};
 
 // check for enemy get position
-private _pos = [_groupMemory select 0, _unit findNearestEnemy _unit] select (_unit distance2D (_unit findNearestEnemy _unit) < 12);
+private _nearestEnemy = _unit findNearestEnemy _unit;
+if (
+    _unit distance2D _nearestEnemy < 18
+    && {(vehicle _nearestEnemy) isKindOf "CAManBase"}
+) exitWith {
+    [_unit, _nearestEnemy, 18, true] call FUNC(doAssault);
+};
+
+// get distance
+private _pos = _groupMemory select 0;
 private _distance2D = _unit distance2D _pos;
 if (_pos isEqualType objNull) then {_pos = getPosATL _pos;};
 
 // look at
 _unit doWatch _pos;
 
-// ACE3 ~ allows unit to clear buildings with aggression - nkenny
-if (_distance2D < 7) then {_unit setVariable ["ace_medical_ai_lastFired", CBA_missionTime];};
+// variables
+_unit setVariable [QGVAR(currentTarget), _pos, GVAR(debug_functions)];
+_unit setVariable [QGVAR(currentTask), "Assault (sympathetic)", GVAR(debug_functions)];
 
-// CQB
-if (RND(0.9) || {_distance2D < 66}) then {
-    // movement
-    _unit setUnitPosWeak "UP";
+// CQB move
+if (_distance2D < 55) then {
 
-    // execute CQB move
+    // ACE3 ~ allows unit to clear buildings with aggression - nkenny
+    if (_distance2D < 7) then {_unit setVariable ["ace_medical_ai_lastFired", CBA_missionTime];};
+
+    // execute move
+    _unit setUnitPosWeak (["UP", "MIDDLE"] select (getSuppression _unit > 0.7));
     _unit doMove _pos;
-    _unit setDestination [_pos, "LEADER PLANNED", false];
+    _unit setDestination [_pos, "LEADER PLANNED", true];
 
-    // variables
-    _unit setVariable [QGVAR(currentTarget), _pos, GVAR(debug_functions)];
-    _unit setVariable [QGVAR(currentTask), "Assault (sympathetic)", GVAR(debug_functions)];
-
-    // debug
-    if (GVAR(debug_functions)) then {
-        ["%1 assaulting (sympathetic) (%2 @ %3m - %4 spots)", side _unit, name _unit, round (_unit distance _pos), count _groupMemory] call FUNC(debugLog);
-        private _sphere = createSimpleObject ["Sign_Sphere10cm_F", AGLtoASL _pos, true];
-        _sphere setObjectTexture [0, [_unit] call FUNC(debugObjectColor)];
-        [{deleteVehicle _this}, _sphere, 12] call CBA_fnc_waitAndExecute;
+    // update variable
+    if (
+        RND(0.97)
+        || {_distance2D < 4 && {[objNull, "VIEW", objNull] checkVisibility [eyePos _unit, (AGLToASL _pos) vectorAdd [0, 0, 1]] isEqualTo 1}}
+    ) then {
+        _groupMemory deleteAt 0;
     };
-} else {
-    // reset
-    _unit setUnitPosWeak "MIDDLE";
 };
 
-// update variable
-if (RND(0.9) || {_distance2D < 4}) then {_groupMemory deleteAt 0;};
+// set speed
+[_unit, _pos] call FUNC(doAssaultSpeed);
+
+// variables
 _group setVariable [QGVAR(groupMemory), _groupMemory, false];
+
+// debug
+if (GVAR(debug_functions)) then {
+    ["%1 assaulting (sympathetic) (%2 @ %3m - %4 spots)", side _unit, name _unit, round (_unit distance _pos), count _groupMemory] call FUNC(debugLog);
+    private _sphere = createSimpleObject ["Sign_Arrow_F", AGLtoASL _pos, true];
+    _sphere setObjectTexture [0, [_unit] call FUNC(debugObjectColor)];
+    [{deleteVehicle _this}, _sphere, 12] call CBA_fnc_waitAndExecute;
+};
 
 // end
 true

--- a/addons/main/functions/UnitAction/fnc_doCheckBody.sqf
+++ b/addons/main/functions/UnitAction/fnc_doCheckBody.sqf
@@ -31,7 +31,7 @@ private _body = allDeadMen select _bodies;
 // execute
 _unit setUnitPosWeak "MIDDLE";
 _unit doMove (getPosATL _body);
-_unit lookAt _body;
+_unit doWatch _body;
 _unit setVariable [QEGVAR(danger,forceMove), true];
 [
     {

--- a/addons/main/functions/UnitAction/fnc_doReposition.sqf
+++ b/addons/main/functions/UnitAction/fnc_doReposition.sqf
@@ -39,7 +39,7 @@ if (_destination != -1) then {
 };
 
 // toggle stance
-_unit setUnitPosWeak selectRandom ["UP", "UP", "MIDDLE"];
+_unit setUnitPosWeak selectRandom ["UP", "MIDDLE"];
 
 // end
 _unit


### PR DESCRIPTION
**Yeah. There is a typo in the branch name.** 

**Changes**
Adds groupMemory check when CQB engaging
Adds visibilty check to determine rooms secured
Adds fix to attempting to suppress targets above ground
Improves FSM by making dodging trigger a "can-fire" rather than assessment state.
Fixes use of lookAt to doWatch

**Description**
Generally improves use of lookAt which fixes AI getting information they are not supposed to have.

Better, more consistent handling og groupMemory, meaning that AI will more effectively clear buildings as teams. Also tweaks many settings to ensure infantry move more intelligently to check buildings. Including visual checks to determine if building positions are cleared.  This fixes units 'clearing' buildings from the outside. 
