### PR TITLE
Improvements to tacticsAssess states

### DIFF
--- a/addons/danger/functions/fnc_tacticsFlank.sqf
+++ b/addons/danger/functions/fnc_tacticsFlank.sqf
@@ -101,14 +101,16 @@ _unit setSpeedMode "FULL";
 // ready group
 _group setFormDir (_unit getDir _target);
 _group setFormation "FILE";
-_units commandMove _overwatch;
 {
     _x setUnitPos "MIDDLE";
     _x setVariable [QGVAR(forceMove), true];
 } foreach _units;
 
+// move
+_units commandMove _overwatch;
+
 // leader smoke ~ deploy concealment to enable movement
-if (!GVAR(disableAutonomousSmoke) && {(getSuppression _unit) isNotEqualTo 0}) then {[_unit, _overwatch] call EFUNC(main,doSmoke);};
+if (!GVAR(disableAutonomousSmoke)) then {[_unit, _overwatch] call EFUNC(main,doSmoke);};
 
 // function
 [{_this call EFUNC(main,doGroupFlank)}, [_cycle, _units, _vehicles, _pos, _overwatch], 2 + random 8] call CBA_fnc_waitAndExecute;

--- a/addons/danger/functions/fnc_tacticsGarrison.sqf
+++ b/addons/danger/functions/fnc_tacticsGarrison.sqf
@@ -56,7 +56,7 @@ if (_units isEqualTo []) exitWith {false};
 
 // buildings ~ sorted by distance
 private _buildings = [_target, BUILDING_DISTANCE, true, false] call EFUNC(main,findBuildings);
-_buildings = _buildings apply { [_unit distance _x, _x] };
+_buildings = _buildings apply { [_unit distanceSqr _x, _x] };
 _buildings sort true;
 _buildings = _buildings apply { _x select 1 };
 
@@ -83,7 +83,7 @@ _group setVariable [QEGVAR(main,currentTactic), "Garrison/Rally", EGVAR(main,deb
 
 // make group ready
 doStop _units;
-_units doWatch _target;
+_units doWatch objNull;
 
 // execute
 {

--- a/addons/main/functions/GroupAction/fnc_doGroupAssault.sqf
+++ b/addons/main/functions/GroupAction/fnc_doGroupAssault.sqf
@@ -19,10 +19,19 @@
 params ["_cycle", "_units", "_pos"];
 
 // update
-_units = _units select {_x call FUNC(isAlive) && {!isPlayer _x}};
-if (_units isEqualTo [] || {_pos isEqualTo []}) exitWith {false};
+_units = _units select {_x call FUNC(isAlive) && {!isPlayer _x} && {!fleeing _x}};
+if (_units isEqualTo [] || {_pos isEqualTo []}) exitWith {
+    // early reset
+    {
+        _x setVariable [QGVAR(forceMove), nil];
+        _x doFollow leader _x;
+        _x forceSpeed -1;
+    } foreach _units;
+    false
+};
 
-private _targetPos = _pos deleteAt 0;
+private _targetPos = _pos select 0;
+
 {
     // manoeuvre
     _x forceSpeed 3;
@@ -32,22 +41,32 @@ private _targetPos = _pos deleteAt 0;
 
     // check enemy
     private _enemy = _x findNearestEnemy _x;
-    if (_x distance2D _enemy < 12) then {_targetPos = getPosATL _enemy;};
-
-    // setpos
-    if (RND(0.75) || {(currentCommand _x) isNotEqualTo "MOVE"}) then {
-        _x lookAt _targetPos;
-        _x doMove _targetPos;
+    if (
+        _x distance2D _enemy < 12
+        && {(vehicle _enemy) isKindOf "CAManBase"}
+        && {_enemy call FUNC(isAlive)}
+    ) then {
+        _targetPos = getPosATL _enemy;
         _x setDestination [_targetPos, "LEADER PLANNED", false]; // added to reduce cover bounding - nkenny
     };
+
+    // set movement
+    if (RND(0.75) || {(currentCommand _x) isNotEqualTo "MOVE"}) then {
+        _x doWatch objNull;
+        _x doMove (_targetPos vectorAdd [-1 + random 2, -1 + random 2, 0.1]);
+    };
 } foreach _units;
+
+// remove  positions
+private _unit = _units select 0;
+_pos = _pos select {_unit distance _x > 5 || {[objNull, "VIEW", objNull] checkVisibility [eyePos _unit, (AGLToASL _x) vectorAdd [0, 0, 1]] isEqualTo 0}};
 
 // recursive cyclic
 if !(_cycle <= 1 || {_units isEqualTo []}) then {
     [
         {_this call FUNC(doGroupAssault)},
         [_cycle - 1, _units, _pos],
-        8
+        3
     ] call CBA_fnc_waitAndExecute;
 };
 


### PR DESCRIPTION
Added Anti-Armour routines to tacticsAssess
- necessitated by changes to enableAttack
Added waypoint check. Units set to "HOLD" will prefer remaining static
Fixed units using binoculars indoors
Timing changes to tacticsAsssault

Improved tacticsAssault
- Better use of groupMemory
- Sorted building positions by closeness