### PR TITLE
Fix params type for the position argument in taskPatrol

### DIFF
--- a/addons/wp/functions/fnc_taskPatrol.sqf
+++ b/addons/wp/functions/fnc_taskPatrol.sqf
@@ -27,7 +27,7 @@ if (canSuspend) exitWith { [FUNC(taskPatrol), _this] call CBA_fnc_directCall; };
 // init
 params [
     ["_group", grpNull, [grpNull, objNull]],
-    ["_pos",[], [[]]],
+    ["_pos",[]],
     ["_radius", TASK_PATROL_SIZE, [0]],
     ["_waypointCount", TASK_PATROL_WAYPOINTCOUNT, [0]],
     ["_area", [], [[]]],


### PR DESCRIPTION
### When merged this pull request will:

1. Fix the params type for the position argument in taskPatrol. It now uses the same type (any) as taskGarrison

The limited type would show script errors when using objects or groups, and then default to the group position. Which probably was the desired position in most cases anyways tbf.