### PR TITLE
Improve assault behaviour

### DIFF
--- a/addons/danger/functions/fnc_brainAssess.sqf
+++ b/addons/danger/functions/fnc_brainAssess.sqf
@@ -48,7 +48,7 @@ if (RND(EGVAR(main,indoorMove)) && {_unit call EFUNC(main,isIndoor)}) exitWith {
 
 // reset look
 _unit setUnitPosWeak "MIDDLE";
-_unit doWatch objNull;
+//_unit doWatch objNull;
 
 // end
 _timeout

--- a/addons/danger/functions/fnc_brainAssess.sqf
+++ b/addons/danger/functions/fnc_brainAssess.sqf
@@ -26,7 +26,7 @@
 params ["_unit", "", "", ["_target", objNull]];
 
 // timeout
-private _timeout = time + 4;
+private _timeout = time + 3;
 
 // check if stopped
 if (!(_unit checkAIFeature "PATH")) exitWith {_timeout};

--- a/addons/danger/functions/fnc_brainEngage.sqf
+++ b/addons/danger/functions/fnc_brainEngage.sqf
@@ -44,16 +44,6 @@ if (
 private _distance = _unit distance2D _target;
 private _groupMemory = (group _unit) getVariable [QEGVAR(main,groupMemory), []];
 
-// sympathetic CQB
-if (
-    _unit checkAIFeature "PATH"
-    && {_groupMemory isNotEqualTo []}
-    && {_distance > (_unit distance2D (_groupMemory param [0, [0, 0, 0]]))}
-) exitWith {
-    [_unit, _groupMemory] call EFUNC(main,doAssaultMemory);
-    _timeout + 2.5
-};
-
 // near, go for CQB
 if (
     _distance < GVAR(cqbRange)

--- a/addons/danger/functions/fnc_brainEngage.sqf
+++ b/addons/danger/functions/fnc_brainEngage.sqf
@@ -42,7 +42,6 @@ if (
 
 // distance + group memory
 private _distance = _unit distance2D _target;
-private _groupMemory = (group _unit) getVariable [QEGVAR(main,groupMemory), []];
 
 // near, go for CQB
 if (

--- a/addons/danger/functions/fnc_brainForced.sqf
+++ b/addons/danger/functions/fnc_brainForced.sqf
@@ -30,7 +30,7 @@ if !(_unit call EFUNC(main,isAlive)) exitWith {
 
 // forced AI or units in vehicles
 if (_unit getVariable [QGVAR(forceMove), false] || {!isNull objectParent _unit}) exitWith {
-    _timeout
+    _timeout + 1.5
 };
 
 // fleeing

--- a/addons/danger/functions/fnc_isForced.sqf
+++ b/addons/danger/functions/fnc_isForced.sqf
@@ -14,7 +14,8 @@
  *
  * Public: No
 */
-_this getVariable [QGVAR(forceMove), false]
+fleeing _this
+|| {_this getVariable [QGVAR(forceMove), false]}
 || {currentCommand _this in ["ATTACK", "GET IN", "ACTION", "HEAL", "REARM", "JOIN"]}
 || {!(_this call EFUNC(main,isAlive))}
 || {(_this getVariable ["ace_medical_ai_healQueue", []]) isNotEqualTo []}

--- a/addons/danger/functions/fnc_isForcedExit.sqf
+++ b/addons/danger/functions/fnc_isForcedExit.sqf
@@ -14,7 +14,6 @@
  *
  * Public: No
 */
-fleeing _this
-|| {_this getVariable [QGVAR(disableAI), false]}
+_this getVariable [QGVAR(disableAI), false]
 || {(behaviour _this) isEqualTo "CARELESS"}
 || {!(_this checkAIFeature "MOVE")}

--- a/addons/danger/functions/fnc_tacticsAssault.sqf
+++ b/addons/danger/functions/fnc_tacticsAssault.sqf
@@ -18,16 +18,23 @@
  *
  * Public: No
 */
-params ["_unit", "_target", ["_units", []], ["_cycle", 16], ["_delay", 70]];
+params ["_group", "_target", ["_units", []], ["_cycle", 16], ["_delay", 70]];
+
+// group is missing
+if (isNull _group) exitWith {false};
+
+// get leader
+if (_group isEqualType objNull) then {_group = group _group;};
+if ((units _group) isEqualTo []) exitWith {false};
+private _unit = leader _group;
 
 // find target
 _target = _target call CBA_fnc_getPos;
-private _group = group _unit;
 
 // reset tactics
 [
     {
-        params [["_group", grpNull], ["_enableAttack", true], ["_isIRLaserOn", false], ["_speedMode", "NORMAL"], ["_formation", "WEDGE"], ["_combatMode", "YELLOW"]];
+        params [["_group", grpNull], ["_enableAttack", true], ["_isIRLaserOn", false], ["_speedMode", "NORMAL"], ["_formation", "WEDGE"]];
         if (!isNull _group) then {
             _group setVariable [QGVAR(isExecutingTactic), nil];
             _group setVariable [QEGVAR(main,currentTactic), nil];
@@ -45,18 +52,15 @@ private _group = group _unit;
             } foreach (units _group);
         };
     },
-    [_group, attackEnabled _group, _unit isIRLaserOn (currentWeapon _unit), speedMode _group, formation _group, combatMode _group],
+    [_group, attackEnabled _group, _unit isIRLaserOn (currentWeapon _unit), speedMode _group, formation _group],
     _delay
 ] call CBA_fnc_waitAndExecute;
 
-// alive unit
-if !(_unit call EFUNC(main,isAlive)) exitWith {false};
 
 // set speed and enableAttack
 _group enableAttack false;
 _group setSpeedMode "FULL";
 _group setFormation "LINE";
-_group setCombatMode "YELLOW";
 
 // find units
 if (_units isEqualTo []) then {

--- a/addons/danger/functions/fnc_tacticsAssault.sqf
+++ b/addons/danger/functions/fnc_tacticsAssault.sqf
@@ -4,7 +4,7 @@
  * Leader calls for extended aggressive assault towards buildings or location
  *
  * Arguments:
- * 0: group leader <OBJECT>
+ * 0: group executing tactics <GROUP> or group leader <UNIT>
  * 1: group threat unit <OBJECT> or position <ARRAY>
  * 2: units in group, default all <ARRAY>
  * 3: how many assault cycles <NUMBER>
@@ -54,7 +54,6 @@ _target = _target call CBA_fnc_getPos;
     [_group, attackEnabled _group, _unit isIRLaserOn (currentWeapon _unit), speedMode _group, formation _group],
     _delay
 ] call CBA_fnc_waitAndExecute;
-
 
 // set speed and enableAttack
 _group enableAttack false;

--- a/addons/danger/functions/fnc_tacticsAssault.sqf
+++ b/addons/danger/functions/fnc_tacticsAssault.sqf
@@ -42,7 +42,6 @@ _target = _target call CBA_fnc_getPos;
             _group enableIRLasers _isIRLaserOn;
             _group setSpeedMode _speedMode;
             _group setFormation _formation;
-            _group setCombatMode _combatMode;
             {
                 _x setVariable [QGVAR(forceMove), nil];
                 _x setVariable [QEGVAR(main,currentTask), nil, EGVAR(main,debug_functions)];

--- a/addons/danger/functions/fnc_tacticsAssault.sqf
+++ b/addons/danger/functions/fnc_tacticsAssault.sqf
@@ -54,7 +54,7 @@ if !(_unit call EFUNC(main,isAlive)) exitWith {false};
 _group enableAttack false;
 _group setSpeedMode "FULL";
 _group setFormation "LINE";
-_group setCombatMode "RED";
+_group setCombatMode "YELLOW";
 
 // find units
 if (_units isEqualTo []) then {

--- a/addons/danger/functions/fnc_tacticsAssault.sqf
+++ b/addons/danger/functions/fnc_tacticsAssault.sqf
@@ -35,6 +35,7 @@ private _group = group _unit;
             _group enableIRLasers _isIRLaserOn;
             _group setSpeedMode _speedMode;
             _group setFormation _formation;
+            _group setCombatMode _combatMode;
             {
                 _x setVariable [QGVAR(forceMove), nil];
                 _x setVariable [QEGVAR(main,currentTask), nil, EGVAR(main,debug_functions)];

--- a/addons/danger/functions/fnc_tacticsAssault.sqf
+++ b/addons/danger/functions/fnc_tacticsAssault.sqf
@@ -39,6 +39,7 @@ private _group = group _unit;
             {
                 _x setVariable [QGVAR(forceMove), nil];
                 _x setVariable [QEGVAR(main,currentTask), nil, EGVAR(main,debug_functions)];
+                _x setUnitPos "AUTO";
                 _x doFollow leader _x;
                 _x forceSpeed -1;
             } foreach (units _group);

--- a/addons/danger/functions/fnc_tacticsAssess.sqf
+++ b/addons/danger/functions/fnc_tacticsAssess.sqf
@@ -175,7 +175,7 @@ if !(_enemies isEqualTo [] || {_unitCount < random 4}) then {
     if (_fortifiedTarget != -1) exitWith {
 
         // basic plan
-        _plan append [TACTICS_FLANK, TACTICS_FLANK];
+        _plan append [TACTICS_FLANK, TACTICS_FLANK, TACTICS_SUPPRESS];
         _pos = _unit getHideFrom (_enemies select _fortifiedTarget);
 
         // combatmode

--- a/addons/danger/functions/fnc_tacticsAssess.sqf
+++ b/addons/danger/functions/fnc_tacticsAssess.sqf
@@ -54,6 +54,7 @@ private _plan = [];
 // sort plans
 _pos = [];
 if !(_enemies isEqualTo [] || {_unitCount < random 4}) then {
+    scopeName "conditionScope";
 
     // sort nearest enemies
     _enemies = _enemies apply {[_x distanceSqr _unit, _x]};

--- a/addons/danger/functions/fnc_tacticsAssess.sqf
+++ b/addons/danger/functions/fnc_tacticsAssess.sqf
@@ -53,7 +53,7 @@ private _plan = [];
 
 // sort plans
 _pos = [];
-if !(_enemies isEqualTo [] || {_unitCount < random 4}) then {
+if !(_enemies isEqualTo [] || {_unitCount < random 3}) then {
     scopeName "conditionScope";
 
     // sort nearest enemies

--- a/addons/danger/functions/fnc_tacticsAssess.sqf
+++ b/addons/danger/functions/fnc_tacticsAssess.sqf
@@ -53,7 +53,7 @@ private _plan = [];
 
 // sort plans
 _pos = [];
-if !(_enemies isEqualTo [] || {_unitCount < random 3}) then {
+if !(_enemies isEqualTo [] || {_unitCount < random 4}) then {
 
     // sort nearest enemies
     _enemies = _enemies apply {[_x distanceSqr _unit, _x]};

--- a/addons/danger/functions/fnc_tacticsAssess.sqf
+++ b/addons/danger/functions/fnc_tacticsAssess.sqf
@@ -244,27 +244,27 @@ _plan = selectRandom _plan;
 switch (_plan) do {
     case TACTICS_FLANK: {
         // flank
-        [{_this call FUNC(tacticsFlank)}, [_unit, _pos, _units], 22 + random 8] call CBA_fnc_waitAndExecute;
+        [{_this call FUNC(tacticsFlank)}, [_group, _pos, _units], 22 + random 8] call CBA_fnc_waitAndExecute;
     };
     case TACTICS_GARRISON: {
         // garrison ~ nb units not carried here - nkenny
-        [{_this call FUNC(tacticsGarrison)}, [_unit, _pos], 10 + random 6] call CBA_fnc_waitAndExecute;
+        [{_this call FUNC(tacticsGarrison)}, [_group, _pos], 10 + random 6] call CBA_fnc_waitAndExecute;
     };
     case TACTICS_ASSAULT: {
         // rush ~ assault
-        [{_this call FUNC(tacticsAssault)}, [_unit, _pos], 6 + random 8] call CBA_fnc_waitAndExecute;
+        [{_this call FUNC(tacticsAssault)}, [_group, _pos], 6 + random 8] call CBA_fnc_waitAndExecute;
     };
     case TACTICS_SUPPRESS: {
         // suppress
-        [{_this call FUNC(tacticsSuppress)}, [_unit, _pos, _units], 4 + random 4] call CBA_fnc_waitAndExecute;
+        [{_this call FUNC(tacticsSuppress)}, [_group, _pos, _units], 4 + random 4] call CBA_fnc_waitAndExecute;
     };
     case TACTICS_ATTACK: {
         // group attacks as one
-        [{_this call FUNC(tacticsAttack)}, [_unit, _pos, _units], 1 + random 1] call CBA_fnc_waitAndExecute;
+        [{_this call FUNC(tacticsAttack)}, [_group, _pos, _units], 1 + random 1] call CBA_fnc_waitAndExecute;
     };
     default {
         // hide from armor
-        [{_this call FUNC(tacticsHide)}, [_unit, _pos, true], 1 + random 3] call CBA_fnc_waitAndExecute;
+        [{_this call FUNC(tacticsHide)}, [_group, _pos, true], 1 + random 3] call CBA_fnc_waitAndExecute;
     };
 };
 

--- a/addons/danger/functions/fnc_tacticsAttack.sqf
+++ b/addons/danger/functions/fnc_tacticsAttack.sqf
@@ -4,7 +4,7 @@
  * Leader calls for all group members to attack a single unit!
  *
  * Arguments:
- * 0: group <GROUP>
+ * 0: group executing tactics <GROUP> or group leader <UNIT>
  * 1: group threat unit <OBJECT> or position <ARRAY>
  * 3: delay until unit is ready again <NUMBER>
  *

--- a/addons/danger/functions/fnc_tacticsAttack.sqf
+++ b/addons/danger/functions/fnc_tacticsAttack.sqf
@@ -4,7 +4,7 @@
  * Leader calls for all group members to attack a single unit!
  *
  * Arguments:
- * 0: group leader <OBJECT>
+ * 0: group <GROUP>
  * 1: group threat unit <OBJECT> or position <ARRAY>
  * 3: delay until unit is ready again <NUMBER>
  *
@@ -16,7 +16,15 @@
  *
  * Public: No
 */
-params ["_unit", ["_target", objNull], ["_units", []], ["_delay", 60]];
+params ["_group", ["_target", objNull], ["_units", []], ["_delay", 60]];
+
+// group is missing
+if (isNull _group) exitWith {false};
+
+// get leader
+if (_group isEqualType objNull) then {_group = group _group;};
+if ((units _group) isEqualTo []) exitWith {false};
+private _unit = leader _group;
 
 // position
 if (_target isEqualType []) then {
@@ -27,7 +35,6 @@ if (_target isEqualType []) then {
 if (isNull _target) exitWith {false};
 
 // update tactics and contact state
-private _group = group _unit;
 _group setVariable [QGVAR(isExecutingTactic), true];
 _group setVariable [QEGVAR(main,currentTactic), "Attacking", EGVAR(main,debug_functions)];
 

--- a/addons/danger/functions/fnc_tacticsContact.sqf
+++ b/addons/danger/functions/fnc_tacticsContact.sqf
@@ -106,7 +106,7 @@ _unit setVariable [QEGVAR(main,currentTask), "Tactics Contact", EGVAR(main,debug
 
 // check suppression status
 private _aggressiveResponse = (units _unit) findIf {getSuppression _x > 0.95 || {!(_x call EFUNC(main,isAlive))}};
-_aggressiveResponse = _count > random 3 && {_unit knowsAbout _enemy > 0.1} && {_aggressiveResponse isEqualTo -1};
+_aggressiveResponse = _count > random 4 && {_unit knowsAbout _enemy > 0.1} && {_aggressiveResponse isEqualTo -1};
 
 // immediate action -- leaders call suppression
 if (
@@ -132,6 +132,9 @@ if (
     // debug
     if (EGVAR(main,debug_functions)) then {
         ["%1 TACTICS SUPPRESSION CONTACT! %2", side _unit, groupId _group] call EFUNC(main,debugLog);
+        private _m = [_unit, "suppression contact!", _unit call EFUNC(main,debugMarkerColor), "mil_warning"] call EFUNC(main,dotMarker);
+        _m setMarkerSizeLocal [0.8, 0.8];
+        [{{deleteMarker _x;true} count _this;}, [_m], _delay + 45] call CBA_fnc_waitAndExecute;
     };
 };
 
@@ -161,6 +164,9 @@ if (
     // debug
     if (EGVAR(main,debug_functions)) then {
         ["%1 TACTICS AGGRESSIVE CONTACT! %2", side _unit, groupId _group] call EFUNC(main,debugLog);
+        private _m = [_unit, "aggressive contact!", _unit call EFUNC(main,debugMarkerColor), "mil_warning"] call EFUNC(main,dotMarker);
+        _m setMarkerSizeLocal [0.8, 0.8];
+        [{{deleteMarker _x;true} count _this;}, [_m], _delay + 45] call CBA_fnc_waitAndExecute;
     };
 };
 
@@ -170,6 +176,9 @@ if (
 // debug
 if (EGVAR(main,debug_functions)) then {
     ["%1 TACTICS CONTACT! %2", side _unit, groupId _group] call EFUNC(main,debugLog);
+    private _m = [_unit, "contact!", _unit call EFUNC(main,debugMarkerColor), "mil_warning"] call EFUNC(main,dotMarker);
+    _m setMarkerSizeLocal [0.8, 0.8];
+    [{{deleteMarker _x;true} count _this;}, [_m], _delay + 45] call CBA_fnc_waitAndExecute;
 };
 
 // end

--- a/addons/danger/functions/fnc_tacticsContact.sqf
+++ b/addons/danger/functions/fnc_tacticsContact.sqf
@@ -110,6 +110,7 @@ _aggressiveResponse = _count > random 4 && {_unit knowsAbout _enemy > 0.1} && {_
 
 // immediate action -- leaders call suppression
 if (
+    false &&
     RND(getSuppression _unit)
     && {_aggressiveResponse}
     && {_unit distance2D _enemy > (GVAR(cqbRange) * 0.5)}
@@ -153,11 +154,15 @@ if (
     && {_unit distance2D _enemy < GVAR(cqbRange)}
     && {_buildings isNotEqualTo []}
 ) exitWith {
-    // execute assault
+    // execute assault ~ forced
     {
         [_x, _buildings] call EFUNC(main,doAssaultMemory);
         _x setVariable [QEGVAR(main,currentTask), "Assault (contact)", EGVAR(main,debug_functions)];
-    } foreach _units;
+
+        // forced movement
+        _x setVariable [QGVAR(forceMove), true];
+        [{_this setVariable [QGVAR(forceMove), nil]}, _x, 5 + random 4] call CBA_fnc_waitAndExecute;
+    } foreach _units select {getSuppression _x < 0.5};
 
     // group variable
     _group setVariable [QEGVAR(main,currentTactic), "Contact! (aggressive)", EGVAR(main,debug_functions)];

--- a/addons/danger/functions/fnc_tacticsContact.sqf
+++ b/addons/danger/functions/fnc_tacticsContact.sqf
@@ -110,7 +110,6 @@ _aggressiveResponse = _count > random 4 && {_unit knowsAbout _enemy > 0.1} && {_
 
 // immediate action -- leaders call suppression
 if (
-    false &&
     RND(getSuppression _unit)
     && {_aggressiveResponse}
     && {_unit distance2D _enemy > (GVAR(cqbRange) * 0.5)}

--- a/addons/danger/functions/fnc_tacticsContact.sqf
+++ b/addons/danger/functions/fnc_tacticsContact.sqf
@@ -16,7 +16,7 @@
  *
  * Public: No
 */
-params [["_unit", objNull, [objNull]], ["_enemy", objNull, [objNull]], ["_delay", 18]];
+params [["_unit", objNull, [objNull]], ["_enemy", objNull, [objNull]], ["_delay", 12]];
 
 // only leader
 if !((leader _unit) isEqualTo _unit || {_unit call EFUNC(main,isAlive)}) exitWith {false};
@@ -55,7 +55,7 @@ _group setVariable [QEGVAR(main,currentTactic), "Contact!", EGVAR(main,debug_fun
         };
     },
     [_group, attackEnabled _group],
-    _delay + random 12
+    _delay + random 18
 ] call CBA_fnc_waitAndExecute;
 
 // change formation and attack state
@@ -112,6 +112,7 @@ _aggressiveResponse = _count > random 4 && {_unit knowsAbout _enemy > 0.1} && {_
 if (
     RND(getSuppression _unit)
     && {_aggressiveResponse}
+    && {_unit distance2D _enemy > (GVAR(cqbRange) * 0.5)}
 ) exitWith {
 
     // get position

--- a/addons/danger/functions/fnc_tacticsFlank.sqf
+++ b/addons/danger/functions/fnc_tacticsFlank.sqf
@@ -4,7 +4,7 @@
  * Group conducts probing flanking manoeuvre
  *
  * Arguments:
- * 0: group leader <OBJECT>
+ * 0: group executing tactics <GROUP> or group leader <UNIT>
  * 1: group target <OBJECT> or position <ARRAY>
  * 2: units in group, default all <ARRAY>
  * 3: how many assault cycles <NUMBER>

--- a/addons/danger/functions/fnc_tacticsFlank.sqf
+++ b/addons/danger/functions/fnc_tacticsFlank.sqf
@@ -19,18 +19,25 @@
  *
  * Public: No
 */
-params ["_unit", "_target", ["_units", []], ["_cycle", 4], ["_overwatch", []], ["_delay", 100]];
+params ["_group", "_target", ["_units", []], ["_cycle", 4], ["_overwatch", []], ["_delay", 100]];
+
+// group is missing
+if (isNull _group) exitWith {false};
+
+// get leader
+if (_group isEqualType objNull) then {_group = group _group;};
+if ((units _group) isEqualTo []) exitWith {false};
+private _unit = leader _group;
 
 // find target
 _target = _target call CBA_fnc_getPos;
 
 // check CQB ~ exit if in close combat other functions will do the work - nkenny
 if (_unit distance2D _target < GVAR(cqbRange)) exitWith {
-    [_unit, _target] call FUNC(tacticsAssault);
+    [_group, _target] call FUNC(tacticsAssault);
     false
 };
 
-private _group = group _unit;
 // reset tactics
 [
     {
@@ -50,9 +57,6 @@ private _group = group _unit;
     [_group, speedMode _unit, formation _unit],
     _delay
 ] call CBA_fnc_waitAndExecute;
-
-// alive unit
-if !(_unit call EFUNC(main,isAlive)) exitWith {false};
 
 // find units
 if (_units isEqualTo []) then {

--- a/addons/danger/functions/fnc_tacticsGarrison.sqf
+++ b/addons/danger/functions/fnc_tacticsGarrison.sqf
@@ -4,7 +4,7 @@
  * Group garrisons buildings near enemies!
  *
  * Arguments:
- * 0: group leader <OBJECT>
+ * 0: group executing tactics <GROUP> or group leader <UNIT>
  * 1: group target <OBJECT> or position <ARRAY>
  * 2: units in group, default all <ARRAY>
  * 3: delay until unit is ready again <NUMBER>
@@ -20,7 +20,7 @@
 #define COVER_DISTANCE 25
 #define BUILDING_DISTANCE 42
 
-params ["_unit", "_target", ["_units", []], ["_delay", 180]];
+params ["_group", "_target", ["_units", []], ["_delay", 180]];
 
 // group is missing
 if (isNull _group) exitWith {false};

--- a/addons/danger/functions/fnc_tacticsGarrison.sqf
+++ b/addons/danger/functions/fnc_tacticsGarrison.sqf
@@ -22,10 +22,17 @@
 
 params ["_unit", "_target", ["_units", []], ["_delay", 180]];
 
+// group is missing
+if (isNull _group) exitWith {false};
+
+// get leader
+if (_group isEqualType objNull) then {_group = group _group;};
+if ((units _group) isEqualTo []) exitWith {false};
+private _unit = leader _group;
+
 // sort target
 _target = _target call CBA_fnc_getPos;
 
-private _group = group _unit;
 // reset tactics
 [
     {
@@ -40,9 +47,6 @@ private _group = group _unit;
     [_group, attackEnabled _group, formation _group],
     _delay
 ] call CBA_fnc_waitAndExecute;
-
-// alive unit
-if !(_unit call EFUNC(main,isAlive)) exitWith {false};
 
 // set speed and enableAttack
 _group setFormation "FILE";

--- a/addons/danger/functions/fnc_tacticsGarrison.sqf
+++ b/addons/danger/functions/fnc_tacticsGarrison.sqf
@@ -91,8 +91,9 @@ _units doWatch objNull;
     [
         {
             params ["_unit", "_pos"];
-            _unit moveTo _pos;
+            //_unit moveTo _pos;
             _unit setDestination [_pos, "LEADER PLANNED", true];
+            _unit doMove _pos;
         }, [_x, _pos], 0.5 + random 2
     ] call CBA_fnc_waitAndExecute;
     _x setVariable [QEGVAR(main,currentTask), "Group Garrison", EGVAR(main,debug_functions)];

--- a/addons/danger/functions/fnc_tacticsHide.sqf
+++ b/addons/danger/functions/fnc_tacticsHide.sqf
@@ -4,7 +4,7 @@
  * Leader calls for group to disperse into cover a special mode with optional anti-armour tactics
  *
  * Arguments:
- * 0: group leader <OBJECT>
+ * 0: group executing tactics <GROUP> or group leader <UNIT>
  * 1: group threat unit <OBJECT> or position <ARRAY>
  * 2: ready anti-tank weapons <BOOL>
  * 3: predefined pieces of cover <ARRAY>

--- a/addons/danger/functions/fnc_tacticsHide.sqf
+++ b/addons/danger/functions/fnc_tacticsHide.sqf
@@ -22,13 +22,20 @@
 #define COVER_DISTANCE 15
 #define BUILDING_DISTANCE 25
 
-params ["_unit", "_target", ["_antiTank", false], ["_cover", []], ["_delay", 240]];
+params ["_group", "_target", ["_antiTank", false], ["_cover", []], ["_delay", 240]];
+
+// group is missing
+if (isNull _group) exitWith {false};
+
+// get leader
+if (_group isEqualType objNull) then {_group = group _group;};
+if ((units _group) isEqualTo []) exitWith {false};
+private _unit = leader _group;
 
 // find target
 _target = _target call CBA_fnc_getPos;
 
 // reset tactics
-private _group = group _unit;
 [
     {
         params [["_group", grpNull], ["_combatMode", "YELLOW"], ["_enableAttack", false], ["_formation", "WEDGE"]];
@@ -44,9 +51,6 @@ private _group = group _unit;
     [_group, combatMode _group, attackEnabled _group, formation _group],
     _delay
 ] call CBA_fnc_waitAndExecute;
-
-// alive unit
-if !(_unit call EFUNC(main,isAlive)) exitWith {false};
 
 // hold-fire combat mode
 _group setFormation "DIAMOND";

--- a/addons/danger/functions/fnc_tacticsHold.sqf
+++ b/addons/danger/functions/fnc_tacticsHold.sqf
@@ -15,14 +15,21 @@
  *
  * Public: No
 */
-params ["_unit", ["_delay", 45]];
+params ["_group", ["_delay", 45]];
+
+// group is missing
+if (isNull _group) exitWith {false};
+
+// get leader
+if (_group isEqualType objNull) then {_group = group _group;};
+if ((units _group) isEqualTo []) exitWith {false};
+private _unit = leader _group;
 
 // known enemy
 private _enemy = _unit findNearestEnemy _unit;
 private _pos = if (isNull _enemy) then {_unit getPos [300, getDir _unit]} else {_unit getHideFrom _enemy};
 
 // reset tactics
-private _group = group _unit;
 [
     {
         params [["_group", grpNull, [grpNull]], ["_enableAttack", false]];

--- a/addons/danger/functions/fnc_tacticsHold.sqf
+++ b/addons/danger/functions/fnc_tacticsHold.sqf
@@ -4,7 +4,7 @@
  * Leader has no orders and waits for the situation to develop. If under fire, the group will take cover.
  *
  * Arguments:
- * 0: group leader <OBJECT>
+ * 0: group executing tactics <GROUP> or group leader <UNIT>
  * 1: delay until unit is ready again <NUMBER>
  *
  * Return Value:

--- a/addons/danger/functions/fnc_tacticsSuppress.sqf
+++ b/addons/danger/functions/fnc_tacticsSuppress.sqf
@@ -4,7 +4,7 @@
  * Leader calls for extended suppressive fire towards buildings or location
  *
  * Arguments:
- * 0: group leader <OBJECT>
+ * 0: group executing tactics <GROUP> or group leader <UNIT>
  * 1: group threat unit <OBJECT> or position <ARRAY>
  * 2: units in group, default all <ARRAY>
  * 3: delay until group is ready <NUMBER>
@@ -17,14 +17,22 @@
  *
  * Public: No
 */
-params ["_unit", "_target", ["_units", []], ["_delay", 17]];
+params ["_group", "_target", ["_units", []], ["_delay", 17]];
+
+// group is missing
+if (isNull _group) exitWith {false};
+
+// get leader
+if (_group isEqualType objNull) then {_group = group _group;};
+if ((units _group) isEqualTo []) exitWith {false};
+private _unit = leader _group;
 
 // find target
 _target = _target call CBA_fnc_getPos;
 
 // exit with flank squad leader cannot suppress from here
 if !([_unit, (ATLToASL _target) vectorAdd [0, 0, 5]] call EFUNC(main,shouldSuppressPosition)) exitWith {
-    [_unit, _target] call FUNC(tacticsFlank);
+    [_group, _target] call FUNC(tacticsFlank);
 };
 
 // sort cycles

--- a/addons/danger/scripts/lambs_danger.fsm
+++ b/addons/danger/scripts/lambs_danger.fsm
@@ -112,8 +112,8 @@ link42[] = {36,24};
 link43[] = {37,3};
 link44[] = {38,39};
 link45[] = {41,40};
-globals[] = {0.000000,0,0,0,0,640,480,1,67,6316128,1,-898.935181,1438.235229,1700.996338,-513.428955,933,884,1};
-window[] = {2,-1,-1,-1,-1,863,104,1544,104,3,951};
+globals[] = {0.000000,0,0,0,0,640,480,1,67,6316128,1,-1206.155884,1607.168823,1969.556274,-696.016479,933,884,1};
+window[] = {2,-1,-1,-1,-1,941,182,1622,182,3,951};
 *//*%FSM</HEAD>*/
 class FSM
 {
@@ -360,7 +360,7 @@ class FSM
                          "_timeout = [_this, _dangerCause, _dangerPos] call lambs_danger_fnc_brainReact;" \n
                          "" \n
                          "// re-insert" \n
-                         "_queue pushBack [8, _dangerPos, _dangerUntil + 3, _this findNearestEnemy _this];"/*%FSM</STATEINIT""">*/;
+                         "_queue pushBack [8, _dangerPos, _dangerUntil + 3, _dangerCausedBy];"/*%FSM</STATEINIT""">*/;
                         precondition = /*%FSM<STATEPRECONDITION""">*/""/*%FSM</STATEPRECONDITION""">*/;
                         class Links
                         {

--- a/addons/danger/scripts/lambs_danger.fsm
+++ b/addons/danger/scripts/lambs_danger.fsm
@@ -24,7 +24,7 @@ item19[] = {"End_Danger",1,250,700.000000,1200.000000,800.000000,1250.000000,0.0
 item20[] = {"no_queue",4,218,700.000000,1075.000000,800.000000,1125.000000,2.000000,"no queue"};
 item21[] = {"timeout",4,218,100.000000,750.000000,200.000000,800.000000,0.000000,"timeout"};
 item22[] = {"timeout",4,218,-250.000000,750.000000,-150.000000,800.000000,0.000000,"timeout"};
-item23[] = {"Reset_foot",2,4346,-375.000000,925.000000,275.000000,975.000000,0.000000,"Reset foot"};
+item23[] = {"Reset_foot",2,250,-375.000000,925.000000,275.000000,975.000000,0.000000,"Reset foot"};
 item24[] = {"true",8,218,500.000000,925.000000,600.000000,975.000000,0.000000,"true"};
 item25[] = {"Check_queue",2,250,700.000000,925.000000,800.000000,975.000000,0.000000,"Check queue"};
 item26[] = {"true",8,218,700.000000,800.000000,800.000000,850.000000,0.000000,"true"};
@@ -41,6 +41,8 @@ item36[] = {"",7,210,545.999939,1221.000000,554.000061,1229.000000,0.000000,""};
 item37[] = {"true",8,218,-325.000000,50.000000,-225.000000,100.000000,0.000000,"true"};
 item38[] = {"Exit",4,218,175.000000,-175.000000,275.000000,-125.000000,2.000000,"Exit"};
 item39[] = {"End_Danger_1",1,250,175.000000,-50.000000,275.000000,0.000000,0.000000,"End Danger"};
+item40[] = {"End_Forced",1,250,1025.000000,925.000000,1125.000000,975.000000,0.000000,"End Forced"};
+item41[] = {"no_queue_and_for",4,218,850.000000,925.000000,950.000000,975.000000,4.000000,"no queue" \n "and forced"};
 version=1;
 class LayoutItems
 {
@@ -96,20 +98,22 @@ link28[] = {23,34};
 link29[] = {24,25};
 link30[] = {25,20};
 link31[] = {25,26};
-link32[] = {26,27};
-link33[] = {27,3};
-link34[] = {28,29};
-link35[] = {30,31};
-link36[] = {31,22};
-link37[] = {32,33};
-link38[] = {33,24};
-link39[] = {34,35};
-link40[] = {35,36};
-link41[] = {36,24};
-link42[] = {37,3};
-link43[] = {38,39};
-globals[] = {0.000000,0,0,0,0,640,480,1,65,6316128,1,-813.988464,339.648987,1448.965088,355.912964,933,884,1};
-window[] = {2,-1,-1,-1,-1,915,156,1596,156,3,951};
+link32[] = {25,41};
+link33[] = {26,27};
+link34[] = {27,3};
+link35[] = {28,29};
+link36[] = {30,31};
+link37[] = {31,22};
+link38[] = {32,33};
+link39[] = {33,24};
+link40[] = {34,35};
+link41[] = {35,36};
+link42[] = {36,24};
+link43[] = {37,3};
+link44[] = {38,39};
+link45[] = {41,40};
+globals[] = {0.000000,0,0,0,0,640,480,1,67,6316128,1,-898.935181,1438.235229,1700.996338,-513.428955,933,884,1};
+window[] = {2,-1,-1,-1,-1,863,104,1544,104,3,951};
 *//*%FSM</HEAD>*/
 class FSM
 {
@@ -246,7 +250,7 @@ class FSM
                         init = /*%FSM<STATEINIT""">*/"" \n
                          "// keep attacking" \n
                          "if (_dangerCause in [8, 9] && {_dangerCausedBy call lambs_main_fnc_isAlive}) then {" \n
-                         "    _queue pushBack [0, _dangerPos, time + lambs_danger_dangerUntil, _this findNearestEnemy _this];" \n
+                         "    _queue pushBack [0, _dangerPos, time + lambs_danger_dangerUntil, _dangerCausedBy];" \n
                          "};"/*%FSM</STATEINIT""">*/;
                         precondition = /*%FSM<STATEPRECONDITION""">*/""/*%FSM</STATEPRECONDITION""">*/;
                         class Links
@@ -457,7 +461,8 @@ class FSM
                         name = "End_Danger";
                         itemno = 19;
                         init = /*%FSM<STATEINIT""">*/"_this setVariable [""lambs_main_currentTask"", nil];" \n
-                         "_this forceSpeed -1;"/*%FSM</STATEINIT""">*/;
+                         "_this forceSpeed -1;" \n
+                         ""/*%FSM</STATEINIT""">*/;
                         precondition = /*%FSM<STATEPRECONDITION""">*/""/*%FSM</STATEPRECONDITION""">*/;
                         class Links
                         {
@@ -471,12 +476,7 @@ class FSM
                         itemno = 23;
                         init = /*%FSM<STATEINIT""">*/"// has living cqb target" \n
                          "if (_engage && {_dangerCausedBy call lambs_main_fnc_isAlive} && {_this distance2D _dangerCausedBy < 35}) then {" \n
-                         "    _queue pushBack [0, _dangerPos, time + lambs_danger_dangerUntil, _dangerCausedBy];" \n
-                         "};" \n
-                         "" \n
-                         "// has group memory" \n
-                         "if (_queue isEqualTo [] && {((group _this) getVariable [""lambs_main_groupMemory"", []]) isNotEqualTo []} ) then {" \n
-                         "    _queue pushBack [10, getPos _this, time + lambs_danger_dangerUntil, objNull];" \n
+                         "    _queue pushBack [0, getPos _dangerCausedBy, time + lambs_danger_dangerUntil, _dangerCausedBy];" \n
                          "};" \n
                          "" \n
                          "//_text = format [""%1 : %2 :  %3"", name _this, _dangerCause call lambs_main_fnc_debugDangerType,_queue apply{[(_x select 0) call lambs_main_fnc_debugDangerType]}];" \n
@@ -515,10 +515,27 @@ class FSM
                 {
                         name = "Check_queue";
                         itemno = 25;
-                        init = /*%FSM<STATEINIT""">*/""/*%FSM</STATEINIT""">*/;
+                        init = /*%FSM<STATEINIT""">*/"" \n
+                         "// has group memory" \n
+                         "if (_queue isEqualTo [] && {((group _this) getVariable [""lambs_main_groupMemory"", []]) isNotEqualTo []} ) then {" \n
+                         "    _queue pushBack [10, getPos _this, time + lambs_danger_dangerUntil, _dangerCausedBy];" \n
+                         "};" \n
+                         "" \n
+                         ""/*%FSM</STATEINIT""">*/;
                         precondition = /*%FSM<STATEPRECONDITION""">*/""/*%FSM</STATEPRECONDITION""">*/;
                         class Links
                         {
+                                /*%FSM<LINK "no_queue_and_for">*/
+                                class no_queue_and_for
+                                {
+                                        itemno = 41;
+                                        priority = 4.000000;
+                                        to="End_Forced";
+                                        precondition = /*%FSM<CONDPRECONDITION""">*/""/*%FSM</CONDPRECONDITION""">*/;
+                                        condition=/*%FSM<CONDITION""">*/"call lambs_danger_fnc_isForced && {_queue isEqualTo []}"/*%FSM</CONDITION""">*/;
+                                        action=/*%FSM<ACTION""">*/""/*%FSM</ACTION""">*/;
+                                };
+                                /*%FSM</LINK>*/
                                 /*%FSM<LINK "no_queue">*/
                                 class no_queue
                                 {
@@ -643,6 +660,18 @@ class FSM
                         };
                 };
                 /*%FSM</STATE>*/
+                /*%FSM<STATE "End_Forced">*/
+                class End_Forced
+                {
+                        name = "End_Forced";
+                        itemno = 40;
+                        init = /*%FSM<STATEINIT""">*/""/*%FSM</STATEINIT""">*/;
+                        precondition = /*%FSM<STATEPRECONDITION""">*/""/*%FSM</STATEPRECONDITION""">*/;
+                        class Links
+                        {
+                        };
+                };
+                /*%FSM</STATE>*/
         };
         initState="Start_Danger";
         finalStates[] =
@@ -650,6 +679,7 @@ class FSM
                 "End_Danger",
                 "End_Danger_vehic",
                 "End_Danger_1",
+                "End_Forced",
         };
 };
 /*%FSM</COMPILE>*/

--- a/addons/main/functions/GroupAction/fnc_doGroupAssault.sqf
+++ b/addons/main/functions/GroupAction/fnc_doGroupAssault.sqf
@@ -39,7 +39,7 @@ private _targetPos = _pos select 0;
 
     // manoeuvre
     _unit forceSpeed 3;
-    _unit setUnitPosWeak (["UP", "MIDDLE"] select (getSuppression _x isNotEqualTo 0));
+    _unit setUnitPos (["UP", "MIDDLE"] select (getSuppression _x isNotEqualTo 0));
     _unit setVariable [QGVAR(currentTask), format ["Group Assault (%1c - %2p)", _cycle, count _pos], GVAR(debug_functions)];
     _unit setVariable [QEGVAR(danger,forceMove), true];
 

--- a/addons/main/functions/GroupAction/fnc_doGroupAssault.sqf
+++ b/addons/main/functions/GroupAction/fnc_doGroupAssault.sqf
@@ -23,50 +23,58 @@ _units = _units select {_x call FUNC(isAlive) && {!isPlayer _x} && {!fleeing _x}
 if (_units isEqualTo [] || {_pos isEqualTo []}) exitWith {
     // early reset
     {
-        _x setVariable [QGVAR(forceMove), nil];
-        _x doFollow leader _x;
+        _x setVariable [QEGVAR(danger,forceMove), nil];
+        _x doFollow (leader _x);
         _x forceSpeed -1;
     } foreach _units;
     false
 };
 
+// get targetPos
 private _targetPos = _pos select 0;
 
 {
+    // get unit
+    private _unit = _x;
+
     // manoeuvre
-    _x forceSpeed 3;
-    _x setUnitPosWeak (["UP", "MIDDLE"] select (getSuppression _x isNotEqualTo 0));
-    _x setVariable [QGVAR(currentTask), "Group Assault", GVAR(debug_functions)];
-    _x setVariable [QEGVAR(danger,forceMove), true];
+    _unit forceSpeed 3;
+    _unit setUnitPosWeak (["UP", "MIDDLE"] select (getSuppression _x isNotEqualTo 0));
+    _unit setVariable [QGVAR(currentTask), format ["Group Assault (%1c - %2p)", _cycle, count _pos], GVAR(debug_functions)];
+    _unit setVariable [QEGVAR(danger,forceMove), true];
 
     // check enemy
-    private _enemy = _x findNearestEnemy _x;
+    /*
+    private _enemy = _unit findNearestEnemy _unit;
     if (
-        _x distance2D _enemy < 12
+        _unit distance2D _enemy < 12
         && {(vehicle _enemy) isKindOf "CAManBase"}
         && {_enemy call FUNC(isAlive)}
     ) then {
         _targetPos = getPosATL _enemy;
-        _x setDestination [_targetPos, "LEADER PLANNED", false]; // added to reduce cover bounding - nkenny
+        _unit forceSpeed 2;
     };
+    */
 
     // set movement
-    if (RND(0.75) || {(currentCommand _x) isNotEqualTo "MOVE"}) then {
-        _x doWatch objNull;
-        _x doMove (_targetPos vectorAdd [-1 + random 2, -1 + random 2, 0.1]);
+    if (((expectedDestination _unit) select 0) distance2D _targetPos > 1) then {
+        _unit doMove _targetPos;
     };
+
+    // remove positions
+    _pos = _pos select {[objNull, "VIEW", objNull] checkVisibility [eyePos _unit, (AGLToASL _x) vectorAdd [0, 0, 0.5]] isEqualTo 0};
 } foreach _units;
 
 // remove  positions
-private _unit = _units select 0;
-_pos = _pos select {_unit distance _x > 5 || {[objNull, "VIEW", objNull] checkVisibility [eyePos _unit, (AGLToASL _x) vectorAdd [0, 0, 1]] isEqualTo 0}};
+_pos = _pos select {(_units select 0) distance _x > 3};
+if (RND(0.95)) then {_pos deleteAt 0;};
 
 // recursive cyclic
 if !(_cycle <= 1 || {_units isEqualTo []}) then {
     [
         {_this call FUNC(doGroupAssault)},
         [_cycle - 1, _units, _pos],
-        3
+        4
     ] call CBA_fnc_waitAndExecute;
 };
 

--- a/addons/main/functions/UnitAction/fnc_doAssault.sqf
+++ b/addons/main/functions/UnitAction/fnc_doAssault.sqf
@@ -38,7 +38,7 @@ private _pos = call {
     // near buildings
     private _buildings = [_getHide, _range, true, false] call FUNC(findBuildings);
     private _distanceSqr = _unit distanceSqr _getHide;
-    _buildings = _buildings select {_x distanceSqr _getHide < _distanceSqr && {_x distance _unit > 1.5}};
+    _buildings = _buildings select {_x distanceSqr _getHide < _distanceSqr && {_x distanceSqr _unit > 2.25}};
 
     // target outdoors
     if (_buildings isEqualTo []) exitWith {

--- a/addons/main/functions/UnitAction/fnc_doAssault.sqf
+++ b/addons/main/functions/UnitAction/fnc_doAssault.sqf
@@ -16,7 +16,7 @@
  *
  * Public: No
 */
-params ["_unit", ["_target", objNull], ["_range", 15], ["_doMove", false]];
+params ["_unit", ["_target", objNull], ["_range", 12], ["_doMove", false]];
 
 // check if stopped
 if (!(_unit checkAIFeature "PATH")) exitWith {false};
@@ -45,6 +45,7 @@ private _pos = call {
 
         if (_unit call FUNC(isIndoor) && {RND(GVAR(indoorMove))}) exitWith {
             _unit setVariable [QGVAR(currentTask), "Stay inside", GVAR(debug_functions)];
+            _unit setUnitPosWeak "MIDDLE";
             getPosATL _unit
         };
 
@@ -53,7 +54,7 @@ private _pos = call {
     };
 
     // updates group memory variable
-    if (_unit distance2D _target < 40) then {
+    if (_unit distance2D _target < 40 && {count (units _unit) > random 4}) then {
         private _group = group _unit;
         private _groupMemory = _group getVariable [QGVAR(groupMemory), []];
         if (_groupMemory isEqualTo []) then {
@@ -62,18 +63,18 @@ private _pos = call {
     };
 
     // select building position
-    _doMove = true;
+    // _doMove = true; ~ uncommented by nkenny. Retrying moveTo scheme. *sigh*
     _getHide = selectRandom _buildings;
     _getHide
 };
 
 // stance and speed
 [_unit, _pos] call FUNC(doAssaultSpeed);
-_unit setUnitPosWeak (["UP", "MIDDLE"] select (getSuppression _unit > 0.7 || {_unit distance2D _pos < 1}));
-_unit doWatch (AGLToASL _getHide);
+_unit setUnitPosWeak (["UP", "MIDDLE"] select (getSuppression _unit > 0.6 || {_unit distance2D _pos < 2}));
 
 // execute
-_unit setDestination [_pos, "LEADER PLANNED", true];
+_unit setDestination [_pos, "LEADER PLANNED", false];
+_unit moveTo _pos;
 if (_doMove) then {_unit doMove _pos;};
 
 // debug

--- a/addons/main/functions/UnitAction/fnc_doAssault.sqf
+++ b/addons/main/functions/UnitAction/fnc_doAssault.sqf
@@ -64,8 +64,7 @@ private _pos = call {
 
     // select building position
     // _doMove = true; ~ uncommented by nkenny. Retrying moveTo scheme. *sigh*
-    _getHide = selectRandom _buildings;
-    _getHide
+    _buildings select 0
 };
 
 // stance and speed

--- a/addons/main/functions/UnitAction/fnc_doAssaultMemory.sqf
+++ b/addons/main/functions/UnitAction/fnc_doAssaultMemory.sqf
@@ -33,54 +33,52 @@ if (_groupMemory isEqualTo []) exitWith {
     false
 };
 
-// sort positions from nearest to furthest
-_groupMemory = _groupMemory apply {[_x distanceSqr _unit, _x]};
-_groupMemory sort true;
-_groupMemory = _groupMemory apply {_x select 1};
-
 // check for enemy get position
 private _nearestEnemy = _unit findNearestEnemy _unit;
+private _vis = [objNull, "VIEW", objNull] checkVisibility [eyePos _unit, aimPos _nearestEnemy] isNotEqualTo 0;
 if (
-    _unit distance2D _nearestEnemy < 18
+    (_vis || {_unit distance2D _nearestEnemy < 15})
+    && {(round (getposATL _unit select 2)) isEqualTo (round ((getPosATL _nearestEnemy) select 2))}
     && {(vehicle _nearestEnemy) isKindOf "CAManBase"}
 ) exitWith {
-    [_unit, _nearestEnemy, 18, true] call FUNC(doAssault);
+    [_unit, _nearestEnemy, 6, false] call FUNC(doAssault);
+    _unit setUnitPosWeak "MIDDLE";
 };
+
+// sort positions from nearest to furthest prioritising positions on the same floor
+_groupMemory = _groupMemory apply {[(round (getposATL _unit select 2)) isEqualTo (round (_x select 2)), _x distanceSqr _unit, _x]};
+_groupMemory sort true;
+_groupMemory = _groupMemory apply {_x select 2};
 
 // get distance
 private _pos = _groupMemory select 0;
 private _distance2D = _unit distance2D _pos;
 if (_pos isEqualType objNull) then {_pos = getPosATL _pos;};
 
-// look at
-_unit doWatch _pos;
-
 // variables
 _unit setVariable [QGVAR(currentTarget), _pos, GVAR(debug_functions)];
 _unit setVariable [QGVAR(currentTask), "Assault (sympathetic)", GVAR(debug_functions)];
 
-// CQB move
-if (_distance2D < 55) then {
-
-    // ACE3 ~ allows unit to clear buildings with aggression - nkenny
-    if (_distance2D < 7) then {_unit setVariable ["ace_medical_ai_lastFired", CBA_missionTime];};
-
-    // execute move
-    _unit setUnitPosWeak (["UP", "MIDDLE"] select (getSuppression _unit > 0.7));
-    _unit doMove _pos;
-    _unit setDestination [_pos, "LEADER PLANNED", true];
-
-    // update variable
-    if (
-        RND(0.97)
-        || {_distance2D < 4 && {[objNull, "VIEW", objNull] checkVisibility [eyePos _unit, (AGLToASL _pos) vectorAdd [0, 0, 1]] isEqualTo 1}}
-    ) then {
-        _groupMemory deleteAt 0;
-    };
-};
+// set stance
+_unit setUnitPosWeak (["UP", "MIDDLE"] select (getSuppression _unit > 0.7 || {_unit call FUNC(isIndoor)}));
 
 // set speed
 [_unit, _pos] call FUNC(doAssaultSpeed);
+
+// ACE3 ~ allows unit to clear buildings with aggression - nkenny
+if (_distance2D < 7) then {_unit setVariable ["ace_medical_ai_lastFired", CBA_missionTime];};
+
+// execute move
+_unit setDestination [_pos, "LEADER PLANNED", true];
+_unit doMove _pos;
+
+// update variable
+if (
+    RND(0.95)
+    || {_distance2D < 4 && {[objNull, "VIEW", objNull] checkVisibility [eyePos _unit, (AGLToASL _pos) vectorAdd [0, 0, 0.5]] isEqualTo 1}}
+) then {
+    _groupMemory deleteAt 0;
+};d
 
 // variables
 _group setVariable [QGVAR(groupMemory), _groupMemory, false];

--- a/addons/main/functions/UnitAction/fnc_doAssaultMemory.sqf
+++ b/addons/main/functions/UnitAction/fnc_doAssaultMemory.sqf
@@ -37,11 +37,10 @@ if (_groupMemory isEqualTo []) exitWith {
 private _nearestEnemy = _unit findNearestEnemy _unit;
 private _vis = [objNull, "VIEW", objNull] checkVisibility [eyePos _unit, aimPos _nearestEnemy] isNotEqualTo 0;
 if (
-    (_vis || {_unit distance2D _nearestEnemy < 15})
-    && {(round (getposATL _unit select 2)) isEqualTo (round ((getPosATL _nearestEnemy) select 2))}
-    && {(vehicle _nearestEnemy) isKindOf "CAManBase"}
+    (vehicle _nearestEnemy) isKindOf "CAManBase"
+    && {_vis || {_unit distance2D _nearestEnemy < 12 && {(round (getposATL _unit select 2)) isEqualTo (round ((getPosATL _nearestEnemy) select 2))}}}
 ) exitWith {
-    [_unit, _nearestEnemy, 6, false] call FUNC(doAssault);
+    [_unit, _nearestEnemy, 8, false] call FUNC(doAssault);
     _unit setUnitPosWeak "MIDDLE";
 };
 
@@ -69,16 +68,12 @@ _unit setUnitPosWeak (["UP", "MIDDLE"] select (getSuppression _unit > 0.7 || {_u
 if (_distance2D < 7) then {_unit setVariable ["ace_medical_ai_lastFired", CBA_missionTime];};
 
 // execute move
-_unit setDestination [_pos, "LEADER PLANNED", true];
 _unit doMove _pos;
+_unit setDestination [_pos, "LEADER PLANNED", _unit distance2D _pos < 18];
 
 // update variable
-if (
-    RND(0.95)
-    || {_distance2D < 4 && {[objNull, "VIEW", objNull] checkVisibility [eyePos _unit, (AGLToASL _pos) vectorAdd [0, 0, 0.5]] isEqualTo 1}}
-) then {
-    _groupMemory deleteAt 0;
-};d
+if (RND(0.95)) then {_groupMemory deleteAt 0;};
+_groupMemory = _groupMemory select {[objNull, "VIEW", objNull] checkVisibility [eyePos _unit, (AGLToASL _x) vectorAdd [0, 0, 0.5]] isEqualTo 0};
 
 // variables
 _group setVariable [QGVAR(groupMemory), _groupMemory, false];

--- a/addons/main/functions/UnitAction/fnc_doFleeing.sqf
+++ b/addons/main/functions/UnitAction/fnc_doFleeing.sqf
@@ -22,7 +22,7 @@ params ["_unit"];
 // check disabled
 if (
     _unit getVariable [QEGVAR(danger,disableAI), false]
-    //|| {!(_unit checkAIFeature "PATH")}
+    || {!(_unit checkAIFeature "PATH")}
     || {!(_unit checkAIFeature "MOVE")}
     || {GVAR(disableAIFleeing)}
     || {currentCommand _unit in ["GET IN", "ACTION", "REARM", "HEAL"]}
@@ -62,9 +62,6 @@ private _distance2D = _unit distance2D _enemy;
 private _pos = (expectedDestination _unit) select 0;
 private _eyePos = eyePos _unit;
 private _suppression = getSuppression _unit;
-
-// allow fleeing
-_unit enableAI "PATH";
 
 // on foot and seen by enemy
 private _onFootAndSeen = _distance2D < 75 || {_suppression > 0.9} || {([objNull, "VIEW", objNull] checkVisibility [_eyePos, eyePos _enemy]) > 0};

--- a/addons/main/functions/UnitAction/fnc_doFleeing.sqf
+++ b/addons/main/functions/UnitAction/fnc_doFleeing.sqf
@@ -22,7 +22,7 @@ params ["_unit"];
 // check disabled
 if (
     _unit getVariable [QEGVAR(danger,disableAI), false]
-    || {!(_unit checkAIFeature "PATH")}
+    //|| {!(_unit checkAIFeature "PATH")}
     || {!(_unit checkAIFeature "MOVE")}
     || {GVAR(disableAIFleeing)}
     || {currentCommand _unit in ["GET IN", "ACTION", "REARM", "HEAL"]}
@@ -62,6 +62,9 @@ private _distance2D = _unit distance2D _enemy;
 private _pos = (expectedDestination _unit) select 0;
 private _eyePos = eyePos _unit;
 private _suppression = getSuppression _unit;
+
+// allow fleeing
+_unit enableAI "PATH";
 
 // on foot and seen by enemy
 private _onFootAndSeen = _distance2D < 75 || {_suppression > 0.9} || {([objNull, "VIEW", objNull] checkVisibility [_eyePos, eyePos _enemy]) > 0};


### PR DESCRIPTION
Added reload check before group assaults
Added debug markers to various Contact states
Added visibility checks to many clearing routines
Added prioritisation of enemies on the same floor to many clearing routines

Improved doAssault and doAssaultMemory
Improved cqb reaction speed by removing doWatch from many functions Improved tacticsAssault building selection criteria Improved FSM exit condition when the group has memory

Fixed unecessary FSM reset when AI is forced
Fixed tacticsGarrison rarely functioning