### PR TITLE
Adds better support for MLRS artillery

### DIFF
--- a/addons/wp/functions/fnc_doArtillery.sqf
+++ b/addons/wp/functions/fnc_doArtillery.sqf
@@ -72,7 +72,7 @@ if (_isMLRS isEqualTo -1) then {
     // get the callout for what this vehicle shoots!
     private _turretPath = _assignedRoles select 1;
     private _turret = (_gun weaponsTurret _turretPath) select 0;
-    _nameSound = getText (configFile >> "CfgWeapons" >> _turret >> "nameSound");
+    private _nameSound = getText (configFile >> "CfgWeapons" >> _turret >> "nameSound");
     if (_nameSound isEqualTo "rockets") exitWith {
         _gun setVariable [QEGVAR(main,isArtilleryMRLS), 1];
         _isMLRS = 1;

--- a/addons/wp/functions/fnc_doArtillery.sqf
+++ b/addons/wp/functions/fnc_doArtillery.sqf
@@ -61,27 +61,8 @@ if !((vehicle _gun) isKindOf "StaticMortar") then {
 };
 
 // MRLS weapons fire almost entire magazine, but with less accuracy
-private _isMLRS = _gun getVariable [QEGVAR(main,isArtilleryMRLS), -1];
-if (_isMLRS isEqualTo -1) then {
-    private _gunner = gunner _gun;
-    private _assignedRoles = assignedVehicleRole _gunner;
-
-    // gunner doesn't have a proper turret!
-    if ((count _assignedRoles) < 2) exitWith {
-        _gun setVariable [QEGVAR(main,isArtilleryMRLS), 0];
-    };
-
-    // get the callout for what this vehicle shoots!
-    private _turretPath = _assignedRoles select 1;
-    private _turret = (_gun weaponsTurret _turretPath) select 0;
-    private _nameSound = getText (configFile >> "CfgWeapons" >> _turret >> "nameSound");
-    if (_nameSound isEqualTo "rockets") exitWith {
-        _gun setVariable [QEGVAR(main,isArtilleryMRLS), 1];
-        _isMLRS = 1;
-    };
-    _gun setVariable [QEGVAR(main,isArtilleryMRLS), 0];
-};
-if (_isMLRS isEqualTo 1) then {
+private _isMLRS = _gun getVariable [QEGVAR(main,isArtilleryMRLS), false];
+if (_isMLRS) then {
     _skipCheckrounds = true;
     _salvo = (gunner _gun) Ammo (currentMuzzle (gunner _gun));
     _rounds = 1;
@@ -187,7 +168,7 @@ if (canFire _gun && {(_caller call EFUNC(main,isAlive))}) then {
             };
 
             // waituntil
-            if (_isMLRS isEqualTo 1) then {sleep 1.3;};
+            if (_isMLRS) then {sleep 1.3;};
             waitUntil {unitReady _gun};
 
         } else {

--- a/addons/wp/functions/fnc_doArtillery.sqf
+++ b/addons/wp/functions/fnc_doArtillery.sqf
@@ -50,7 +50,6 @@ _gun doWatch _pos;
 private _direction = _gun getDir _pos;
 private _center = _pos getPos [_accuracy * 0.33, -_direction];
 private _offset = 0;
-private _salvo = 1;
 
 // heavier artillery fires more rounds, more accurately
 if !((vehicle _gun) isKindOf "StaticMortar") then {

--- a/addons/wp/functions/fnc_taskArtilleryRegister.sqf
+++ b/addons/wp/functions/fnc_taskArtilleryRegister.sqf
@@ -34,6 +34,27 @@ private _artillery = [];
 private _artillery = _artillery select { getNumber (configOf _x >> "artilleryScanner") > 0 };
 if (_artillery isEqualTo []) exitWith {false};
 
+// check for MLRS
+{
+    private _gunner = gunner _x;
+    private _assignedRoles = assignedVehicleRole _gunner;
+
+    // gunner doesn't have a proper turret!
+    if ((count _assignedRoles) < 2) then {
+        _gun setVariable [QEGVAR(main,isArtilleryMRLS), false];
+    } else {
+        // get the callout for what this vehicle shoots!
+        private _turretPath = _assignedRoles select 1;
+        private _turret = (_gun weaponsTurret _turretPath) select 0;
+        private _nameSound = getText (configFile >> "CfgWeapons" >> _turret >> "nameSound");
+        if (_nameSound isEqualTo "rockets") then {
+            _gun setVariable [QEGVAR(main,isArtilleryMRLS), true];
+        } else {
+            _gun setVariable [QEGVAR(main,isArtilleryMRLS), false];
+        };
+    };
+} forEach _artillery;
+
 // add to faction global
 [QGVAR(RegisterArtillery), _artillery] call CBA_fnc_serverEvent;
 

--- a/addons/wp/functions/fnc_taskArtilleryRegister.sqf
+++ b/addons/wp/functions/fnc_taskArtilleryRegister.sqf
@@ -36,21 +36,20 @@ if (_artillery isEqualTo []) exitWith {false};
 
 // check for MLRS
 {
-    private _gunner = gunner _x;
-    private _assignedRoles = assignedVehicleRole _gunner;
+    private _assignedRoles = assignedVehicleRole (gunner _x);
 
     // gunner doesn't have a proper turret!
     if ((count _assignedRoles) < 2) then {
-        _gun setVariable [QEGVAR(main,isArtilleryMRLS), false];
+        _x setVariable [QEGVAR(main,isArtilleryMRLS), false];
     } else {
         // get the callout for what this vehicle shoots!
         private _turretPath = _assignedRoles select 1;
-        private _turret = (_gun weaponsTurret _turretPath) select 0;
+        private _turret = (_x weaponsTurret _turretPath) select 0;
         private _nameSound = getText (configFile >> "CfgWeapons" >> _turret >> "nameSound");
         if (_nameSound isEqualTo "rockets") then {
-            _gun setVariable [QEGVAR(main,isArtilleryMRLS), true];
+            _x setVariable [QEGVAR(main,isArtilleryMRLS), true];
         } else {
-            _gun setVariable [QEGVAR(main,isArtilleryMRLS), false];
+            _x setVariable [QEGVAR(main,isArtilleryMRLS), false];
         };
     };
 } forEach _artillery;

--- a/addons/wp/stringtable.xml
+++ b/addons/wp/stringtable.xml
@@ -74,7 +74,7 @@
             <Chinesesimp>主炮齐射</Chinesesimp>
         </Key>
         <Key ID="STR_Lambs_WP_Module_TaskArtillery_MainSalvo_Tooltip">
-            <English>Number of rounds in the main salvo</English>
+            <English>Number of rounds in the main salvo. MLRS artillery ignore this value.</English>
             <Czech>Počet střel v hlavní salvě</Czech>
             <German>Anzahl an Schüssen der Hauptsalve.</German>
             <Polish>Liczba pocisków w głównej salwie</Polish>

--- a/addons/wp/stringtable.xml
+++ b/addons/wp/stringtable.xml
@@ -75,7 +75,7 @@
         </Key>
         <Key ID="STR_Lambs_WP_Module_TaskArtillery_MainSalvo_Tooltip">
             <English>Number of rounds in the main salvo. MLRS artillery ignore this value.</English>
-            <German>Anzahl an Schüssen der Hauptsalve.</German>
+            <German>Anzahl an Schüssen der Hauptsalve. MLRS-Artillerie ignoriert diesen Wert.</German>
         </Key>
         <Key ID="STR_Lambs_WP_Module_TaskArtillery_Spread_DisplayName">
             <English>Spread</English>

--- a/addons/wp/stringtable.xml
+++ b/addons/wp/stringtable.xml
@@ -75,12 +75,7 @@
         </Key>
         <Key ID="STR_Lambs_WP_Module_TaskArtillery_MainSalvo_Tooltip">
             <English>Number of rounds in the main salvo. MLRS artillery ignore this value.</English>
-            <Czech>Počet střel v hlavní salvě</Czech>
             <German>Anzahl an Schüssen der Hauptsalve.</German>
-            <Polish>Liczba pocisków w głównej salwie</Polish>
-            <Russian>Количество снарядов в главном залпе</Russian>
-            <Italian>Numero di colpi nella salva principale</Italian>
-            <Chinesesimp>主炮齐射的炮弹回合</Chinesesimp>
         </Key>
         <Key ID="STR_Lambs_WP_Module_TaskArtillery_Spread_DisplayName">
             <English>Spread</English>


### PR DESCRIPTION
**Improves Dynamic Artillery support for MLRS style launchers.** 
- MLRS launchers will now shoot their entire magazine. Launchers with large magazines will still clump their salvos in 2's or 4's to ensure good spread on target. 
- MLRS launchers will have no check rounds-- which make them quite dangerous in numbers. 
