### PR TITLE
Improve tacticsFlank feature

### DIFF
--- a/addons/danger/functions/fnc_tacticsFlank.sqf
+++ b/addons/danger/functions/fnc_tacticsFlank.sqf
@@ -15,7 +15,7 @@
  * Bool
  *
  * Example:
- * [bob, angryBob] call lambs_danger__fnc_tacticsFlank;
+ * [bob, angryBob] call lambs_danger_fnc_tacticsFlank;
  *
  * Public: No
 */
@@ -100,21 +100,18 @@ _group setVariable [QEGVAR(main,currentTactic), "Flanking", EGVAR(main,debug_fun
 _unit setSpeedMode "FULL";
 
 // prevent units from being mounted!
-(units _unit) allowGetIn false;
+((units _unit) select {((assignedVehicleRole _x) select 0) isEqualTo "cargo"}) allowGetIn false;
 
 // ready group
 _group setFormDir (_unit getDir _target);
 _group setFormation "FILE";
 {
-    _x setUnitPos "MIDDLE";
+    _x setUnitPos "DOWN";
     _x setVariable [QGVAR(forceMove), true];
 } foreach _units;
 
-// move
-_units commandMove _overwatch;
-
 // leader smoke ~ deploy concealment to enable movement
-if (!GVAR(disableAutonomousSmoke)) then {[_unit, _overwatch] call EFUNC(main,doSmoke);};
+if (!GVAR(disableAutonomousSmokeGrenades)) then {[_unit, _overwatch] call EFUNC(main,doSmoke);};
 
 // function
 [{_this call EFUNC(main,doGroupFlank)}, [_cycle, _units, _vehicles, _pos, _overwatch], 2 + random 8] call CBA_fnc_waitAndExecute;

--- a/addons/main/functions/GroupAction/fnc_doGroupFlank.sqf
+++ b/addons/main/functions/GroupAction/fnc_doGroupFlank.sqf
@@ -21,7 +21,7 @@
 params ["_cycle", "_units", "_vehicles", "_pos", "_overwatch"];
 
 // update
-_units = _units select { _x call FUNC(isAlive) && { _x distance2D _overwatch > 12 } && { !isPlayer _x } };
+_units = _units select { _x call FUNC(isAlive) && { !isPlayer _x } };
 _vehicles = _vehicles select { canFire _x };
 
 private _posASL = AGLtoASL (selectRandom _pos);
@@ -31,7 +31,7 @@ private _posASL = AGLtoASL (selectRandom _pos);
     _x setUnitPos (["MIDDLE", "DOWN"] select _suppressed);
 
     // move
-    _x doMove _overwatch;
+    _x doMove (_overwatch vectorAdd [-2 + random 4, -2 + random 4, 0]);
     _x setDestination [_overwatch, "LEADER PLANNED", true];
     _x setVariable [QEGVAR(danger,forceMove), !_suppressed];
 


### PR DESCRIPTION
Improved survivability by making AI first drop prone, then delaying movement
Fixed header issue
Fixed wrong variable being checked when throwing smoke grenades
Fixed crew dismounting vehicles to conduct flanks. VERY silly with APCs...