### PR TITLE
Fix extra space in doCallout

### DIFF
--- a/addons/main/functions/fnc_doCallout.sqf
+++ b/addons/main/functions/fnc_doCallout.sqf
@@ -58,7 +58,7 @@ switch (toLower(_callout)) do {
         _callout = selectRandom ["HealthSomebodyHelpMe", "HealthNeedHelp", "HealthWounded", "HealthMedic", "CombatGenericE"];
     };
     case ("flank"): {
-        _callout = selectRandom ["OnYourFeet", "Advance", "FlankLeft ", "FlankRight"];
+        _callout = selectRandom ["OnYourFeet", "Advance", "FlankLeft", "FlankRight"];
     };
 };
 


### PR DESCRIPTION
Fix extra space in doCallout 'FlankLeft'

Yeah. That is annoying.