### PR TITLE
Tweak chance to enter group tactics mode

### DIFF
--- a/addons/danger/functions/fnc_tacticsAssess.sqf
+++ b/addons/danger/functions/fnc_tacticsAssess.sqf
@@ -53,7 +53,7 @@ private _plan = [];
 
 // sort plans
 _pos = [];
-if !(_enemies isEqualTo [] || {_unitCount < random 3}) then {
+if !(_enemies isEqualTo [] || {_unitCount < random 4}) then {
     scopeName "conditionScope";
 
     // sort nearest enemies


### PR DESCRIPTION
Improved group tactics assessment

Reduces chance that smaller groups of 2-3 soldiers enter a proper group-tactic mode. Instead these can rely on the standard FSM to add survivability.