### PR TITLE
Rework position commands

### DIFF
--- a/addons/danger/functions/fnc_tacticsAssess.sqf
+++ b/addons/danger/functions/fnc_tacticsAssess.sqf
@@ -104,7 +104,7 @@ if !(_enemies isEqualTo [] || {_unitCount < random 4}) then {
     if (EGVAR(main,Loaded_WP) && {[side _unit] call EFUNC(WP,sideHasArtillery)}) then {
         private _artilleryTarget = _enemies findIf {
             _unit distance2D _x > RANGE_MID
-            && {([_unit, getPos _x, RANGE_NEAR] call EFUNC(main,findNearbyFriendlies)) isEqualTo []}
+            && {([_unit, POSITIONAGL(_x), RANGE_NEAR] call EFUNC(main,findNearbyFriendlies)) isEqualTo []}
         };
         if (_artilleryTarget != -1) then {
             [_unit, _unit getHideFrom (_enemies select _artilleryTarget)] call EFUNC(main,doCallArtillery);   // possibly add delay? ~ nkenny

--- a/addons/danger/functions/fnc_tacticsFlank.sqf
+++ b/addons/danger/functions/fnc_tacticsFlank.sqf
@@ -78,7 +78,7 @@ if (_overwatch isEqualTo []) then {
     _overwatch = _overwatch select {!(surfaceIsWater (_x select 1))};
     _overwatch sort true;
     _overwatch = _overwatch apply {_x select 1};
-    if (_overwatch isEqualTo []) then {_overwatch pushBack ([getPos _unit, _distance2D, 100, 8, _target] call EFUNC(main,findOverwatch));};
+    if (_overwatch isEqualTo []) then {_overwatch pushBack ([POSITIONAGL(_unit), _distance2D, 100, 8, _target] call EFUNC(main,findOverwatch));};
     _overwatch = _overwatch select 0;
 };
 

--- a/addons/danger/scripts/lambs_danger.fsm
+++ b/addons/danger/scripts/lambs_danger.fsm
@@ -476,7 +476,7 @@ class FSM
                         itemno = 23;
                         init = /*%FSM<STATEINIT""">*/"// has living cqb target" \n
                          "if (_engage && {_dangerCausedBy call lambs_main_fnc_isAlive} && {_this distance2D _dangerCausedBy < 35}) then {" \n
-                         "    _queue pushBack [0, getPos _dangerCausedBy, time + lambs_danger_dangerUntil, _dangerCausedBy];" \n
+                         "    _queue pushBack [0, ASLtoAGL (getPosASL _dangerCausedBy), time + lambs_danger_dangerUntil, _dangerCausedBy];" \n
                          "};" \n
                          "" \n
                          "//_text = format [""%1 : %2 :  %3"", name _this, _dangerCause call lambs_main_fnc_debugDangerType,_queue apply{[(_x select 0) call lambs_main_fnc_debugDangerType]}];" \n
@@ -518,7 +518,7 @@ class FSM
                         init = /*%FSM<STATEINIT""">*/"" \n
                          "// has group memory" \n
                          "if (_queue isEqualTo [] && {((group _this) getVariable [""lambs_main_groupMemory"", []]) isNotEqualTo []} ) then {" \n
-                         "    _queue pushBack [10, getPos _this, time + lambs_danger_dangerUntil, _dangerCausedBy];" \n
+                         "    _queue pushBack [10, ASLtoAGL (getPosASL _this), time + lambs_danger_dangerUntil, _dangerCausedBy];" \n
                          "};" \n
                          "" \n
                          ""/*%FSM</STATEINIT""">*/;

--- a/addons/main/functions/GroupAction/fnc_doGroupStaticDeploy.sqf
+++ b/addons/main/functions/GroupAction/fnc_doGroupStaticDeploy.sqf
@@ -84,7 +84,7 @@ private _EH = _gunner addEventHandler ["WeaponAssembled", {
 
 // find position ~ kept simple for now!
 if (_weaponPos isEqualTo []) then {
-    _weaponPos = [getPos (leader _gunner), 0, 15, 2, 0, 0.19, 0, [], [getPos _assistant, getPos _assistant]] call BIS_fnc_findSafePos;
+    _weaponPos = [POSITIONAGL((leader _gunner)), 0, 15, 2, 0, 0.19, 0, [], [POSITIONAGL(_assistant), POSITIONAGL(_assistant)]] call BIS_fnc_findSafePos;
     _weaponPos set [2, 0];
 };
 

--- a/addons/main/functions/GroupAction/fnc_doGroupStaticPack.sqf
+++ b/addons/main/functions/GroupAction/fnc_doGroupStaticPack.sqf
@@ -79,7 +79,7 @@ _assistant setUnitPosWeak "MIDDLE";
 _assistant forceSpeed 24;
 _assistant setVariable [QEGVAR(danger,forceMove), true];
 _assistant setVariable [QGVAR(currentTask), "Pack Static Weapon", GVAR(debug_functions)];
-_assistant setVariable [QGVAR(currentTarget), getPos _gunner, GVAR(debug_functions)];
+_assistant setVariable [QGVAR(currentTarget), POSITIONAGL(_gunner), GVAR(debug_functions)];
 _assistant doMove getPosATL (vehicle _gunner);
 
 // do it

--- a/addons/main/functions/UnitAction/fnc_doAssaultCQB.sqf
+++ b/addons/main/functions/UnitAction/fnc_doAssaultCQB.sqf
@@ -98,7 +98,7 @@ if (_buildingPos isEqualTo []) then {
 
 // repeat
 if (_buildingPos isNotEqualTo []) then {
-    [{_this call FUNC(doAssaultCQB)}, [_unit, getPos _unit], 7] call CBA_fnc_waitAndExecute;
+    [{_this call FUNC(doAssaultCQB)}, [_unit, POSITIONAGL(_unit)], 7] call CBA_fnc_waitAndExecute;
 // or end
 } else {
     // remove force move!

--- a/addons/main/functions/fnc_findClosestTarget.sqf
+++ b/addons/main/functions/fnc_findClosestTarget.sqf
@@ -40,7 +40,7 @@ _units = _units select {
 };
 if (_area isNotEqualTo []) then {
     _area params ["_a", "_b", "_angle", "_isRectangle", ["_c", -1]];
-    _units = _units select { (getPos _x) inArea [_pos, _a, _b, _angle, _isRectangle, _c] };
+    _units = _units select { (POSITIONAGL(_x)) inArea [_pos, _a, _b, _angle, _isRectangle, _c] };
 };
 if (_units isEqualTo []) exitWith { objNull };
 

--- a/addons/main/functions/fnc_findCover.sqf
+++ b/addons/main/functions/fnc_findCover.sqf
@@ -58,7 +58,7 @@ if (_dangerPos isNotEqualTo [0, 0, 1.8]) then {
         _buildingPos = [_obj, 5] call CBA_fnc_buildingPositions;
         if (_buildingPos isEqualTo []) then {
             (boundingBox _obj) params ["_boundA", "_boundB"];
-            _pos = (getPos _obj) vectorAdd (selectRandom [_boundA, _boundB]);
+            _pos = (POSITIONAGL(_obj)) vectorAdd (selectRandom [_boundA, _boundB]);
             // there is no building pos, so this is either vegetation or some building without building pos
             // set height to 0 otherwise the pos will be right above the object
             _pos set [2, 0.1];

--- a/addons/main/functions/fnc_isNight.sqf
+++ b/addons/main/functions/fnc_isNight.sqf
@@ -23,4 +23,4 @@ if (behaviour _unit isEqualTo "STEALTH"
 ) exitWith {false};
 
 // night check
-(getPos _unit) getEnvSoundController "night" isEqualTo 1
+(POSITIONAGL(_unit)) getEnvSoundController "night" isEqualTo 1

--- a/addons/main/script_macros.hpp
+++ b/addons/main/script_macros.hpp
@@ -18,6 +18,8 @@
     _unit \
 }
 
+#define POSITIONAGL(object) ASLtoAGL (getPosASL object)
+
 // #define DISABLE_COMPILE_CACHE
 
 #ifdef DISABLE_COMPILE_CACHE

--- a/addons/wp/functions/Modules/fnc_moduleArtillery.sqf
+++ b/addons/wp/functions/Modules/fnc_moduleArtillery.sqf
@@ -27,7 +27,7 @@ switch (_mode) do {
             }, {
                 params ["_side", "_salvo", "_spread", "_skipCheckround", "_pos"];
                 [_side, _pos, objNull, _salvo, _spread, _skipCheckround] call FUNC(taskArtillery);
-            }, [_side, _salvo, _spread, _skipCheckround, getPos _logic]] call CBA_fnc_waitUntilAndExecute;
+            }, [_side, _salvo, _spread, _skipCheckround, POSITIONAGL(_logic)]] call CBA_fnc_waitUntilAndExecute;
         };
         if (_isCuratorPlaced) then {
             [LSTRING(Module_TaskArtillery_DisplayName),

--- a/addons/wp/functions/Modules/fnc_moduleArtilleryRegister.sqf
+++ b/addons/wp/functions/Modules/fnc_moduleArtilleryRegister.sqf
@@ -44,7 +44,7 @@ switch (_mode) do {
                 private _area = _logic getVariable ["objectarea", [10, 10, 0, false, -1]];
                 _area params ["_a", "_b", "_angle", "_isRectangle", ["_c", -1]];
 
-                _groups = allGroups select { (leader _x) inArea [(getPos _logic), _a, _b, _angle, _isRectangle, _c] };
+                _groups = allGroups select { (leader _x) inArea [(POSITIONAGL(_logic)), _a, _b, _angle, _isRectangle, _c] };
             };
             _groups = _groups arrayIntersect _groups;
             {

--- a/addons/wp/functions/Modules/fnc_moduleAssault.sqf
+++ b/addons/wp/functions/Modules/fnc_moduleAssault.sqf
@@ -44,7 +44,7 @@ switch (_mode) do {
                             _deleteAfterStartup = true;
                             [objNull, format [LLSTRING(SettingIsOnlyForLocalGroups), LLSTRING(Module_TaskAssault_DeleteOnStartup_DisplayName)]] call BIS_fnc_showCuratorFeedbackMessage;
                         };
-                        [QGVAR(taskAssault), [_group, [_logic, getPos _logic] select _deleteAfterStartup, _retreat, _threshold, _cycle, false], leader _group] call CBA_fnc_targetEvent;
+                        [QGVAR(taskAssault), [_group, [_logic, POSITIONAGL(_logic)] select _deleteAfterStartup, _retreat, _threshold, _cycle, false], leader _group] call CBA_fnc_targetEvent;
 
                         if (_deleteAfterStartup) then {
                             deleteVehicle _logic;
@@ -77,7 +77,7 @@ switch (_mode) do {
                         _data params ["_targetIndex", "_retreat", "_threshold", "_cycle"];
                         private _target = _targets select _targetIndex;
                         if !(local _group) then {
-                            _target = getPos _target;
+                            _target = POSITIONAGL(_target);
                         };
                         [QGVAR(taskAssault), [_group, _target, _retreat, _threshold, _cycle, false], leader _group] call CBA_fnc_targetEvent;
                         if (_target isNotEqualTo _logic) then {
@@ -101,7 +101,7 @@ switch (_mode) do {
             private _threshold = _logic getVariable [QGVAR(DistanceThreshold), TASK_ASSAULT_DISTANCETHRESHOLD];
             private _cycle = _logic getVariable [QGVAR(CycleTime), TASK_ASSAULT_CYCLETIME];
             {
-                [QGVAR(taskAssault), [_x, [_logic, getPos _logic] select _deleteAfterStartup, _retreat, _threshold, _cycle, false], leader _x] call CBA_fnc_targetEvent;
+                [QGVAR(taskAssault), [_x, [_logic, POSITIONAGL(_logic)] select _deleteAfterStartup, _retreat, _threshold, _cycle, false], leader _x] call CBA_fnc_targetEvent;
             } forEach _groups;
             if (_deleteAfterStartup) then {
                 deleteVehicle _logic;

--- a/addons/wp/functions/Modules/fnc_moduleCQB.sqf
+++ b/addons/wp/functions/Modules/fnc_moduleCQB.sqf
@@ -43,7 +43,7 @@ switch (_mode) do {
                             _deleteAfterStartup = true;
                             [objNull, format [LLSTRING(SettingIsOnlyForLocalGroups), LLSTRING(Module_TaskCQB_DeleteOnStartUp_DisplayName)]] call BIS_fnc_showCuratorFeedbackMessage;
                         };
-                        [QGVAR(taskCQB), [_group, [_logic, getPos _logic] select _deleteAfterStartup, _radius, _cycle, nil, false], leader _group] call CBA_fnc_targetEvent;
+                        [QGVAR(taskCQB), [_group, [_logic, POSITIONAGL(_logic)] select _deleteAfterStartup, _radius, _cycle, nil, false], leader _group] call CBA_fnc_targetEvent;
                         if (_deleteAfterStartup) then {
                             deleteVehicle _logic;
                         };
@@ -73,7 +73,7 @@ switch (_mode) do {
                         _data params ["_targetIndex", "_radius", "_cycle"];
                         private _target = _targets select _targetIndex;
                         if !(local _group) then {
-                            _target = getPos _target;
+                            _target = POSITIONAGL(_target);
                         };
                         [QGVAR(taskCQB), [_group, _target, _radius, _cycle, nil, false], leader _group] call CBA_fnc_targetEvent;
                         if (_logic isNotEqualTo _target) then {
@@ -100,7 +100,7 @@ switch (_mode) do {
             {
                 private _target = _logic;
                 if !(local _x) then {
-                    _target = getPos _target;
+                    _target = POSITIONAGL(_target);
                 };
                 [QGVAR(taskCQB), [_x, _target, _radius, _cycle, _area, false], leader _x] call CBA_fnc_targetEvent;
             } forEach _groups;

--- a/addons/wp/functions/Modules/fnc_moduleCamp.sqf
+++ b/addons/wp/functions/Modules/fnc_moduleCamp.sqf
@@ -41,7 +41,7 @@ switch (_mode) do {
                         _args params ["_groups", "_logic"];
                         _data params ["_groupIndex", "_range", "_exitWP", "_teleport", "_patrol"];
                         private _group = _groups select _groupIndex;
-                        [QGVAR(taskCamp), [_group, getPos _logic, _range, nil, _teleport, _patrol, _exitWP - 1], leader _group] call CBA_fnc_targetEvent;
+                        [QGVAR(taskCamp), [_group, POSITIONAGL(_logic), _range, nil, _teleport, _patrol, _exitWP - 1], leader _group] call CBA_fnc_targetEvent;
                         deleteVehicle _logic;
                     }, {
                         params ["", "_logic"];
@@ -69,7 +69,7 @@ switch (_mode) do {
                         params ["_data", "_args"];
                         _args params ["_group", "_logic", "_targets"];
                         _data params ["_targetIndex", "_range", "_exitWP", "_teleport", "_patrol"];
-                        [QGVAR(taskCamp), [_group, getPos (_targets select _targetIndex), _range, nil, _teleport, _patrol, _exitWP - 1], leader _group] call CBA_fnc_targetEvent;
+                        [QGVAR(taskCamp), [_group, POSITIONAGL((_targets select _targetIndex)), _range, nil, _teleport, _patrol, _exitWP - 1], leader _group] call CBA_fnc_targetEvent;
                         deleteVehicle _logic;
                     }, {
                         params ["", "_logic"];
@@ -90,7 +90,7 @@ switch (_mode) do {
             private _patrol = _logic getVariable [QGVAR(Patrol), TASK_CAMP_PATROL];
             private _exitWP = _logic getVariable [QGVAR(exitWP), TASK_CAMP_EXITWP];
             {
-                [QGVAR(taskCamp), [_x, getPos _logic, _range, _area, _teleport, _patrol, _exitWP - 1], leader _x] call CBA_fnc_targetEvent;
+                [QGVAR(taskCamp), [_x, POSITIONAGL(_logic), _range, _area, _teleport, _patrol, _exitWP - 1], leader _x] call CBA_fnc_targetEvent;
             } forEach _groups;
             deleteVehicle _logic;
         };

--- a/addons/wp/functions/Modules/fnc_moduleCreep.sqf
+++ b/addons/wp/functions/Modules/fnc_moduleCreep.sqf
@@ -39,7 +39,7 @@ switch (_mode) do {
                         params ["_data", "_args"];
                         _args params ["_group", "_logic"];
                         _data params ["_range", "_cycle", "_movingCenter", "_playerOnly"];
-                        private _args = [[_group, _range, _cycle, nil, getPos _logic, _playerOnly], [_group, _range, _cycle, nil, nil, _playerOnly]] select _movingCenter;
+                        private _args = [[_group, _range, _cycle, nil, POSITIONAGL(_logic), _playerOnly], [_group, _range, _cycle, nil, nil, _playerOnly]] select _movingCenter;
                         [QGVAR(taskCreep), _args, leader _group] call CBA_fnc_targetEvent;
                         deleteVehicle _logic;
                     }, {
@@ -64,7 +64,7 @@ switch (_mode) do {
             private _movingCenter = _logic getVariable [QGVAR(MovingCenter), TASK_CREEP_MOVINGCENTER];
             private _playerOnly = _logic getVariable [QGVAR(PlayersOnly), TASK_CREEP_PLAYERSONLY];
             {
-                private _args = [[_x, _range, _cycle, _area, getPos _logic, _playerOnly], [_x, _range, _cycle, _area, nil, _playerOnly]] select _movingCenter;
+                private _args = [[_x, _range, _cycle, _area, POSITIONAGL(_logic), _playerOnly], [_x, _range, _cycle, _area, nil, _playerOnly]] select _movingCenter;
                 [QGVAR(taskCreep), _args, leader _x] call CBA_fnc_targetEvent;
             } forEach _groups;
             deleteVehicle _logic;

--- a/addons/wp/functions/Modules/fnc_moduleGarrison.sqf
+++ b/addons/wp/functions/Modules/fnc_moduleGarrison.sqf
@@ -41,7 +41,7 @@ switch (_mode) do {
                         _args params ["_groups", "_logic"];
                         _data params ["_groupIndex", "_range", "_exitCondition", "_sortByHeight", "_teleport", "_patrol"];
                         private _group = _groups select _groupIndex;
-                        [QGVAR(taskGarrison), [_group, getPos _logic, _range, nil, _teleport, _sortByHeight, _exitCondition - 2, _patrol], leader _group] call CBA_fnc_targetEvent;
+                        [QGVAR(taskGarrison), [_group, POSITIONAGL(_logic), _range, nil, _teleport, _sortByHeight, _exitCondition - 2, _patrol], leader _group] call CBA_fnc_targetEvent;
                         deleteVehicle _logic;
                     }, {
                         params ["", "_logic"];
@@ -71,7 +71,7 @@ switch (_mode) do {
                         _args params ["_group", "_logic", "_targets"];
                         _data params ["_targetIndex", "_range", "_exitCondition", "_sortByHeight", "_teleport", "_patrol"];
                         private _target = _targets select _targetIndex;
-                        [QGVAR(taskGarrison), [_group, getPos _target, _range, nil, _teleport, _sortByHeight, _exitCondition - 2, _patrol], leader _group] call CBA_fnc_targetEvent;
+                        [QGVAR(taskGarrison), [_group, POSITIONAGL(_target), _range, nil, _teleport, _sortByHeight, _exitCondition - 2, _patrol], leader _group] call CBA_fnc_targetEvent;
                         deleteVehicle _logic;
                     }, {
                         params ["", "_logic"];
@@ -93,7 +93,7 @@ switch (_mode) do {
             private _exitCondition = _logic getVariable [QGVAR(ExitConditions), TASK_GARRISON_EXITCONDITIONS];
             private _patrol = _logic getVariable [QGVAR(Patrol), TASK_GARRISON_PATROL];
             {
-                [QGVAR(taskGarrison), [_x, getPos _logic, _range, _area, _teleport, _sortByHeight, _exitCondition, _patrol], leader _x] call CBA_fnc_targetEvent;
+                [QGVAR(taskGarrison), [_x, POSITIONAGL(_logic), _range, _area, _teleport, _sortByHeight, _exitCondition, _patrol], leader _x] call CBA_fnc_targetEvent;
             } forEach _groups;
 
             deleteVehicle _logic;

--- a/addons/wp/functions/Modules/fnc_moduleHunt.sqf
+++ b/addons/wp/functions/Modules/fnc_moduleHunt.sqf
@@ -44,7 +44,7 @@ switch (_mode) do {
                         _data params ["_range", "_cycle", "_movingCenter", "_playerOnly", "_enableReinforcement", "_doUGL"];
                         private _args = [_group, _range, _cycle, nil, nil, _playerOnly, _enableReinforcement, _doUGL];
                         if !(_movingCenter) then {
-                            _args set [4, getPos _logic];
+                            _args set [4, POSITIONAGL(_logic)];
                         };
                         [QGVAR(taskHunt), _args, leader _group] call CBA_fnc_targetEvent;
                         deleteVehicle _logic;
@@ -75,7 +75,7 @@ switch (_mode) do {
             {
                 private _args = [_x, _range, _cycle, _area, nil, _playerOnly, _enableReinforcement, _doUGL];
                 if !(_movingCenter) then {
-                    _args set [4, getPos _logic];
+                    _args set [4, POSITIONAGL(_logic)];
                 };
                 [QGVAR(taskHunt), _args, leader _x] call CBA_fnc_targetEvent;
             } forEach _groups;

--- a/addons/wp/functions/Modules/fnc_modulePatrol.sqf
+++ b/addons/wp/functions/Modules/fnc_modulePatrol.sqf
@@ -40,7 +40,7 @@ switch (_mode) do {
                         _args params ["_groups", "_logic"];
                         _data params ["_groupIndex", "_range", "_waypointCount", "_moveWaypoint", "_enableReinforcement"];
                         private _group = _groups select _groupIndex;
-                        [QGVAR(taskPatrol), [_group, getPos _logic, _range, _waypointCount, [], _moveWaypoint, _enableReinforcement], leader _group] call CBA_fnc_targetEvent;
+                        [QGVAR(taskPatrol), [_group, POSITIONAGL(_logic), _range, _waypointCount, [], _moveWaypoint, _enableReinforcement], leader _group] call CBA_fnc_targetEvent;
                         deleteVehicle _logic;
                     }, {
                         params ["", "_logic"];
@@ -69,7 +69,7 @@ switch (_mode) do {
                         _args params ["_targets", "_logic", "_group"];
                         _data params ["_targetIndex", "_range", "_waypointCount", "_moveWaypoint", "_enableReinforcement"];
                         private _target = _targets select _targetIndex;
-                        [QGVAR(taskPatrol), [_group, getPos _target, _range, _waypointCount, [], _moveWaypoint, _enableReinforcement], leader _group] call CBA_fnc_targetEvent;
+                        [QGVAR(taskPatrol), [_group, POSITIONAGL(_target), _range, _waypointCount, [], _moveWaypoint, _enableReinforcement], leader _group] call CBA_fnc_targetEvent;
                         if (_logic isNotEqualTo _target) then {
                             deleteVehicle _logic;
                         };
@@ -92,7 +92,7 @@ switch (_mode) do {
             private _enableReinforcement = _logic getVariable [QGVAR(EnableReinforcement), TASK_PATROL_ENABLEREINFORCEMENT];
             private _waypointCount =_logic getVariable [QGVAR(WaypointCount), TASK_PATROL_WAYPOINTCOUNT];
             {
-                [QGVAR(taskPatrol), [_x, getPos _logic, _range, _waypointCount, _area, _moveWaypoint, _enableReinforcement], leader _x] call CBA_fnc_targetEvent;
+                [QGVAR(taskPatrol), [_x, POSITIONAGL(_logic), _range, _waypointCount, _area, _moveWaypoint, _enableReinforcement], leader _x] call CBA_fnc_targetEvent;
             } forEach _groups;
             deleteVehicle _logic;
         };

--- a/addons/wp/functions/Modules/fnc_moduleRush.sqf
+++ b/addons/wp/functions/Modules/fnc_moduleRush.sqf
@@ -41,7 +41,7 @@ switch (_mode) do {
                         params ["_data", "_args"];
                         _args params ["_group", "_logic"];
                         _data params ["_range", "_cycle", "_movingCenter", "_playerOnly"];
-                        private _args = [[_group, _range, _cycle, nil, getPos _logic, _playerOnly], [_group, _range, _cycle, nil, nil, _playerOnly]] select _movingCenter;
+                        private _args = [[_group, _range, _cycle, nil, POSITIONAGL(_logic), _playerOnly], [_group, _range, _cycle, nil, nil, _playerOnly]] select _movingCenter;
                         [QGVAR(taskRush), _args, leader _group] call CBA_fnc_targetEvent;
                         deleteVehicle _logic;
                     }, {
@@ -66,7 +66,7 @@ switch (_mode) do {
             private _movingCenter = _logic getVariable [QGVAR(MovingCenter), TASK_RUSH_MOVINGCENTER];
             private _playerOnly = _logic getVariable [QGVAR(PlayersOnly), TASK_RUSH_PLAYERSONLY];
             {
-                private _args = [[_x, _range, _cycle, _area, getPos _logic, _playerOnly], [_x, _range, _cycle, _area, nil, _playerOnly]] select _movingCenter;
+                private _args = [[_x, _range, _cycle, _area, POSITIONAGL(_logic), _playerOnly], [_x, _range, _cycle, _area, nil, _playerOnly]] select _movingCenter;
                 [QGVAR(taskRush), _args, leader _x] call CBA_fnc_targetEvent;
             } forEach _groups;
             deleteVehicle _logic;

--- a/addons/wp/functions/ZEN/fnc_setCamp.sqf
+++ b/addons/wp/functions/ZEN/fnc_setCamp.sqf
@@ -5,5 +5,5 @@ GET_GROUPS_CONTEXT(_targets);
 
 {
     private _leader = leader _x;
-    [QGVAR(taskCamp), [_x, getPos _leader], _leader] call CBA_fnc_targetEvent;
+    [QGVAR(taskCamp), [_x, POSITIONAGL(_leader)], _leader] call CBA_fnc_targetEvent;
 } forEach _targets;

--- a/addons/wp/functions/ZEN/fnc_setGarrison.sqf
+++ b/addons/wp/functions/ZEN/fnc_setGarrison.sqf
@@ -5,5 +5,5 @@ GET_GROUPS_CONTEXT(_targets);
 
 {
     private _leader = leader _x;
-    [QGVAR(taskGarrison), [_x, getPos _leader], _leader] call CBA_fnc_targetEvent;
+    [QGVAR(taskGarrison), [_x, POSITIONAGL(_leader)], _leader] call CBA_fnc_targetEvent;
 } forEach _targets;

--- a/addons/wp/functions/ZEN/fnc_setPatrol.sqf
+++ b/addons/wp/functions/ZEN/fnc_setPatrol.sqf
@@ -5,5 +5,5 @@ GET_GROUPS_CONTEXT(_targets);
 
 {
     private _leader = leader _x;
-    [QGVAR(taskPatrol), [_x, getPos _leader], _leader] call CBA_fnc_targetEvent;
+    [QGVAR(taskPatrol), [_x, POSITIONAGL(_leader)], _leader] call CBA_fnc_targetEvent;
 } forEach _targets;

--- a/addons/wp/functions/fnc_doArtillery.sqf
+++ b/addons/wp/functions/fnc_doArtillery.sqf
@@ -119,7 +119,7 @@ if (canFire _gun && {(_caller call EFUNC(main,isAlive))}) then {
 
     // caller marker
     if (EGVAR(main,debug_functions)) then {
-        (_markerList select 0) setMarkerPos (getPos _caller);
+        (_markerList select 0) setMarkerPos (POSITIONAGL(_caller));
         (_markerList select 0) setMarkerDir (_caller getDir _center);
         (_markerList select 0) setMarkerText format ["Spotter (%1M)", round (_caller distance2D _center)];
     };

--- a/addons/wp/functions/fnc_taskAssault.sqf
+++ b/addons/wp/functions/fnc_taskAssault.sqf
@@ -90,7 +90,7 @@ _group setFormation "LINE";
             {
                 params ["_args", "_handle"];
                 _args params ["_unit", "_group", "_retreat", "_threshold"];
-                private _destination = (_group getVariable [QGVAR(taskAssaultDestination), getPos _unit]) call CBA_fnc_getPos;
+                private _destination = (_group getVariable [QGVAR(taskAssaultDestination), POSITIONAGL(_unit)]) call CBA_fnc_getPos;
 
                 // exit
                 if (!(_unit call EFUNC(main,isAlive)) || {_unit distance2D _destination < _threshold} || {_destination isEqualTo [0,0,0]}) exitWith {

--- a/addons/wp/functions/fnc_taskCQB.sqf
+++ b/addons/wp/functions/fnc_taskCQB.sqf
@@ -49,7 +49,7 @@ private _fnc_find = {
 
     if (_area isNotEqualTo []) then {
         _area params ["_a", "_b", "_angle", "_isRectangle", ["_c", -1]];
-        _building = _building select { (getPos _x) inArea [_pos, _a, _b, _angle, _isRectangle, _c] };
+        _building = _building select { (POSITIONAGL(_x)) inArea [_pos, _a, _b, _angle, _isRectangle, _c] };
     };
 
     if (_building isEqualTo []) exitWith { objNull };
@@ -62,7 +62,7 @@ private _fnc_find = {
 // check for enemies
 private _fnc_enemy = {
     params ["_building", "_group"];
-    private _pos = [ getPos _building, getPos leader _group] select isNull _building;
+    private _pos = [ POSITIONAGL(_building), POSITIONAGL((leader _group))] select isNull _building;
     private _enemy = (leader _group) findNearestEnemy _pos;
     if (isNull _enemy || {_pos distance2D _enemy < 25}) exitWith { _enemy };
     objNull
@@ -136,7 +136,7 @@ private _fnc_act = {
             } else {
                 // teleport debug (unit sometimes gets stuck due to Arma buildings )
                 if (RND(0.6) && {_x call EFUNC(main,isIndoor)} && {_x distance _buildingPosSelected > 45} && {!([_x, 50] call CBA_fnc_nearPlayer)}) then {
-                    _x setVehiclePosition [getPos _x, [], 3.5];
+                    _x setVehiclePosition [POSITIONAGL(_x), [], 3.5];
                 };
 
                 // distance to building is too far?

--- a/addons/wp/functions/fnc_taskCamp.sqf
+++ b/addons/wp/functions/fnc_taskCamp.sqf
@@ -61,8 +61,8 @@ private _weapons = nearestObjects [_pos, ["Landvehicle"], _range, true];
 _weapons = _weapons select { simulationEnabled _x && { !isObjectHidden _x } && { locked _x != 2 } && { (_x emptyPositions "Gunner") > 0 } };
 if (_area isNotEqualTo []) then {
     _area params ["_a", "_b", "_angle", "_isRectangle", ["_c", -1]];
-    _weapons = _weapons select {(getPos _x) inArea [_pos, _a, _b, _angle, _isRectangle, _c]};
-    _buildings = _buildings select {(getPos _x) inArea [_pos, _a, _b, _angle, _isRectangle, _c]};
+    _weapons = _weapons select {(POSITIONAGL(_x)) inArea [_pos, _a, _b, _angle, _isRectangle, _c]};
+    _buildings = _buildings select {(POSITIONAGL(_x)) inArea [_pos, _a, _b, _angle, _isRectangle, _c]};
 };
 
 // STAGE 1 - PATROL --------------------------
@@ -117,7 +117,7 @@ reverse _units;
             },
             {
                 params ["_unit", "_target"];
-                if (surfaceIsWater (getPos _unit) || (_unit distance _target > 2)) exitWith { _unit doFollow (leader _unit); };
+                if (surfaceIsWater (getPosASL _unit) || (_unit distance _target > 2)) exitWith { _unit doFollow (leader _unit); };
                 doStop _unit;
                 _unit setUnitPos selectRandom ["UP", "UP", "MIDDLE"];
             },
@@ -192,7 +192,7 @@ private _dir = random 360;
         unitReady _unit
     }, {
         params ["_unit", "_target", "_center", "_anim"];
-        if (surfaceIsWater (getPos _unit) || (_unit distance2D _target > 1)) exitWith { _unit doFollow (leader _unit); };
+        if (surfaceIsWater (getPosASL _unit) || (_unit distance2D _target > 1)) exitWith { _unit doFollow (leader _unit); };
         [_unit, _anim, 2] call EFUNC(main,doAnimation);
 
         _unit disableAI "ANIM";
@@ -229,7 +229,7 @@ _wp setWaypointStatements ["true", "
 ];
 
 // followup orders - just stay put or move into buildings!
-private _wp2 = _group addWaypoint [[_pos, getPos selectRandom _buildings] select (count _buildings > 4), _range / 4];
+private _wp2 = _group addWaypoint [[_pos, POSITIONAGL((selectRandom _buildings))] select (count _buildings > 4), _range / 4];
 
 // set exitWP
 if (_exitWP == -1) then {

--- a/addons/wp/functions/fnc_taskCreep.sqf
+++ b/addons/wp/functions/fnc_taskCreep.sqf
@@ -45,7 +45,7 @@ private _fnc_creepOrders = {
 
     // distance
     private _newDist = (leader _group) distance2D _target;
-    private _in_forest = ((selectBestPlaces [getPos (leader _group), 2, "(forest + trees)*0.5", 1, 1]) select 0) select 1;
+    private _in_forest = ((selectBestPlaces [POSITIONAGL((leader _group)), 2, "(forest + trees)*0.5", 1, 1]) select 0) select 1;
 
     // danger mode? go for it!
     if (behaviour (leader _group) isEqualTo "COMBAT") exitWith {
@@ -121,7 +121,7 @@ waitUntil {
     if (!isNull _target) then {
         [_group, _target] call _fnc_creepOrders;
         if (EGVAR(main,debug_functions)) then {
-            ["%1 taskCreep: %2 targets %3 (%4) at %5 Meters -- Stealth %6/%7", side _group, groupID _group, name _target, _group knowsAbout _target, floor (leader _group distance2D _target), ((selectBestPlaces [getPos leader _group, 2, "(forest + trees)*0.5", 1, 1]) select 0) select 1, str(unitPos leader _group)] call EFUNC(main,debugLog);
+            ["%1 taskCreep: %2 targets %3 (%4) at %5 Meters -- Stealth %6/%7", side _group, groupID _group, name _target, _group knowsAbout _target, floor (leader _group distance2D _target), ((selectBestPlaces [POSITIONAGL((leader _group)), 2, "(forest + trees)*0.5", 1, 1]) select 0) select 1, str(unitPos leader _group)] call EFUNC(main,debugLog);
         };
         sleep _cycle;
     } else {

--- a/addons/wp/functions/fnc_taskGarrison.sqf
+++ b/addons/wp/functions/fnc_taskGarrison.sqf
@@ -56,7 +56,7 @@ _houses = _houses select { RND(0.5) || {lineIntersects [AGLToASL _x, (AGLToASL _
 if (_area isNotEqualTo []) then {
     _area params ["_a", "_b", "_angle", "_isRectangle", ["_c", -1]];
     _houses = _houses select { _x inArea [_pos, _a, _b, _angle, _isRectangle, _c] };
-    _weapons = _weapons select {(getPos _x) inArea [_pos, _a, _b, _angle, _isRectangle, _c]};
+    _weapons = _weapons select {(POSITIONAGL(_x)) inArea [_pos, _a, _b, _angle, _isRectangle, _c]};
 };
 [_houses, true] call CBA_fnc_Shuffle;
 
@@ -203,7 +203,7 @@ private _fnc_addEventHandler = {
                 unitReady _unit
             }, {
                 params ["_unit", "_target"];
-                if (surfaceIsWater (getPos _unit) || (_unit distance _target > 1.5)) exitWith { _unit doFollow (leader _unit); };
+                if (surfaceIsWater (getPosASL _unit) || (_unit distance _target > 1.5)) exitWith { _unit doFollow (leader _unit); };
                 _unit disableAI "PATH";
                 _unit setUnitPos selectRandom ["UP", "UP", "MIDDLE"];
             }, [_x, _house]

--- a/addons/wp/functions/fnc_taskPatrol.sqf
+++ b/addons/wp/functions/fnc_taskPatrol.sqf
@@ -67,7 +67,7 @@ if (isNil QFUNC(TaskPatrol_WaypointStatement)) then {
     DFUNC(TaskPatrol_WaypointStatement) = {
         private _group = group this;
         private _radius = _group getVariable [QGVAR(TaskPatrol_Radius), 200];
-        private _pos = _group getVariable [QGVAR(TaskPatrol_Position), getPos (leader _group)];
+        private _pos = _group getVariable [QGVAR(TaskPatrol_Position), POSITIONAGL((leader _group))];
         private _area = _group getVariable [QGVAR(TaskPatrol_Area), []];;
 
         {


### PR DESCRIPTION
### When merged this pull request will: 
Replace all instances of ``getPos`` with the appropriate position command, usually ``ASLtoAGL getPosASL``. This is because ``getPos`` is not a suitable command for getting an objects 3D position due to [inconsistent behaviour and slow execution](https://community.bistudio.com/wiki/getPos).

1. *Describe what this pull request will do*
Add a new macro for getting 3D positions in positionAGL format and utilize it to replace all instances of ``getPos``
3. *Each change in a separate line*
New macro ``POSITIONAGL(object)``
Removed ``getPos`` in favour of the new macro
