### PR TITLE
Improved Handling of assaulting Group Memory positions

### DIFF
--- a/addons/danger/functions/fnc_brainAssess.sqf
+++ b/addons/danger/functions/fnc_brainAssess.sqf
@@ -29,7 +29,12 @@ params ["_unit", "", "", ["_target", objNull]];
 private _timeout = time + 3;
 
 // check if stopped
-if (!(_unit checkAIFeature "PATH")) exitWith {_timeout};
+if (
+    !(_unit checkAIFeature "PATH")
+    || {((behaviour _unit)) isEqualTo "STEALTH"}
+    || {(currentCommand _unit) isEqualTo "STOP"}
+    || {(combatMode _unit) in ["BLUE", "GREEN"]}
+) exitWith {_timeout};
 
 // group memory
 private _groupMemory = (group _unit) getVariable [QEGVAR(main,groupMemory), []];

--- a/addons/danger/functions/fnc_brainEngage.sqf
+++ b/addons/danger/functions/fnc_brainEngage.sqf
@@ -55,6 +55,9 @@ if (
     _timeout + 1.4
 };
 
+// set low stance
+_unit setUnitPosWeak "MIDDLE";
+
 // far, try to suppress
 if (
     _distance < 500
@@ -64,11 +67,12 @@ if (
     && {_type isEqualTo DANGER_CANFIRE}
 ) exitWith {
     private _posASL = ATLtoASL (_unit getHideFrom _target);
-    if (((ASLtoAGL _posASL) select 2) > 6) exitWith {
-        _timeout + 3
+    if (((ASLtoAGL _posASL) select 2) > 6) then {
+        _posASL = ASLtoAGL _posASL;
+        _posASL set [2, 0.5];
+        _posASL = AGLToASL _posASL
     };
     _unit forceSpeed 0;
-    _unit setUnitPosWeak "MIDDLE";
     _unit suppressFor 4;
     [_unit, _posASL vectorAdd [0, 0, 0.8], true] call EFUNC(main,doSuppress);
     _timeout + 4

--- a/addons/danger/functions/fnc_tacticsAssault.sqf
+++ b/addons/danger/functions/fnc_tacticsAssault.sqf
@@ -80,7 +80,7 @@ private _housePos = [];
 _group setVariable [QEGVAR(main,groupMemory), _housePos];
 
 // add base position
-_housePos pushBack _target;
+if (_housePos isEqualTo []) then {_housePos pushBack _target;};
 
 // set tasks
 _unit setVariable [QEGVAR(main,currentTarget), _target, EGVAR(main,debug_functions)];
@@ -103,7 +103,7 @@ if (!GVAR(disableAutonomousSmokeGrenades)) then {
     [_unit, _target] call EFUNC(main,doSmoke);
 
     // grenadier smoke
-    [{_this call EFUNC(main,doUGL)}, [_units, _target, "shotSmokeX"], 3] call CBA_fnc_waitAndExecute;
+    [{_this call EFUNC(main,doUGL)}, [_units, _target, "shotSmoke"], 3] call CBA_fnc_waitAndExecute;
 };
 
 // ready group
@@ -117,7 +117,7 @@ _units doWatch objNull;
 } foreach (_units select {getSuppression _x < 0.7 && {needReload _x > 0.6}});
 
 // execute function
-[_cycle, _units, _housePos] call EFUNC(main,doGroupAssault);
+[{_this call EFUNC(main,doGroupAssault)}, [_cycle, _units, _housePos], 2 + random 3] call CBA_fnc_waitAndExecute;
 
 // debug
 if (EGVAR(main,debug_functions)) then {

--- a/addons/danger/functions/fnc_tacticsAssess.sqf
+++ b/addons/danger/functions/fnc_tacticsAssess.sqf
@@ -126,7 +126,7 @@ if !(_enemies isEqualTo [] || {_unitCount < random 4}) then {
         && {_inside || {_x call EFUNC(main,isIndoor)}}
     };
     if (_nearIndoorTarget != -1) exitWith {
-        _plan append [TACTICS_GARRISON, TACTICS_ASSAULT, TACTICS_ASSAULT];
+        _plan append [TACTICS_ASSAULT, TACTICS_ASSAULT];
         _pos = _unit getHideFrom (_enemies select _nearIndoorTarget);
     };
 
@@ -136,7 +136,7 @@ if !(_enemies isEqualTo [] || {_unitCount < random 4}) then {
         private _currentWP = _waypoints select ((currentWaypoint _group) min ((count _waypoints) - 1));
         private _holdWP = ((waypointType _currentWP) isEqualTo "HOLD") && {(waypointPosition _currentWP) distance2D _unit < RANGE_MID};
         if (_holdWP) exitWith {
-            _plan append [TACTICS_GARRISON, TACTICS_HIDE];
+            _plan append [TACTICS_HIDE, TACTICS_HIDE];
             _pos = waypointPosition _currentWP;
             breakOut "conditionScope";
         };

--- a/addons/main/functions/GroupAction/fnc_doGroupAssault.sqf
+++ b/addons/main/functions/GroupAction/fnc_doGroupAssault.sqf
@@ -36,29 +36,22 @@ private _targetPos = _pos select 0;
 {
     // get unit
     private _unit = _x;
+    private _assaultPos = _targetPos;
 
     // manoeuvre
     _unit forceSpeed 3;
-    _unit setUnitPos (["UP", "MIDDLE"] select (getSuppression _x isNotEqualTo 0));
+    _unit setUnitPos (["UP", "MIDDLE"] select ((getSuppression _x) isNotEqualTo 0 || {_unit distance2D _assaultPos > 8}));
     _unit setVariable [QGVAR(currentTask), format ["Group Assault (%1c - %2p)", _cycle, count _pos], GVAR(debug_functions)];
     _unit setVariable [QEGVAR(danger,forceMove), true];
 
-    // check enemy
-    /*
-    private _enemy = _unit findNearestEnemy _unit;
-    if (
-        _unit distance2D _enemy < 12
-        && {(vehicle _enemy) isKindOf "CAManBase"}
-        && {_enemy call FUNC(isAlive)}
-    ) then {
-        _targetPos = getPosATL _enemy;
-        _unit forceSpeed 2;
+    // modify movement (if far)
+    if (_unit distanceSqr _assaultPos > 400 && {!([_unit] call FUNC(isIndoor))}) then {
+        _assaultPos = _unit getPos [20, _unit getDir _assaultPos];
     };
-    */
-
     // set movement
-    if (((expectedDestination _unit) select 0) distance2D _targetPos > 1) then {
-        _unit doMove _targetPos;
+    if (((expectedDestination _unit) select 0) distance2D _assaultPos > 1) then {
+        _unit doMove _assaultPos;
+        _unit setDestination [_assaultPos, "LEADER PLANNED", true];
     };
 
     // remove positions

--- a/addons/main/functions/UnitAction/fnc_doAssault.sqf
+++ b/addons/main/functions/UnitAction/fnc_doAssault.sqf
@@ -28,12 +28,15 @@ _unit setVariable [QGVAR(currentTask), "Assault", GVAR(debug_functions)];
 private _getHide = _unit getHideFrom _target;
 
 // check visibility
-private _vis = [objNull, "VIEW", objNull] checkVisibility [eyePos _unit, aimPos _target] isNotEqualTo 0;
+private _vis = [objNull, "VIEW", objNull] checkVisibility [eyePos _unit, aimPos _target] isEqualTo 1;
 private _buildings = [];
 private _pos = call {
 
     // can see target!
-    if (_vis) exitWith {getPosATL _target};
+    if (_vis) exitWith {
+        _unit lookAt (aimPos _target);
+        getPosATL _target
+    };
 
     // near buildings
     private _buildings = [_getHide, _range, true, false] call FUNC(findBuildings);

--- a/addons/main/functions/UnitAction/fnc_doDodge.sqf
+++ b/addons/main/functions/UnitAction/fnc_doDodge.sqf
@@ -24,6 +24,7 @@ if (
     GVAR(disableAIDodge)
     || {!(_unit checkAIFeature "MOVE")}
     || {!(_unit checkAIFeature "PATH")}
+    || {!((currentWeapon _unit) isEqualTo (primaryWeapon _unit))}
 ) exitWith {false};
 
 // dodge


### PR DESCRIPTION
Added 'half step' movement to doGroupAssault and doAssaultMemory to force movement
Improved tacticsAssault timings, and prevents useless positions to be added
Improved tactical assessment when assaulting
Improved units about to fire rockets are prevented from dodging
Fixed Units set to hold fire, stopped, or ordered to remain stealthy will no longer clear buildings
Fixed potential 'shooting into air' occurrences
Fixed situations where AI would ignore enemies behind them!
Misc performance improvements

### When merged this pull request will:
Individual actions: In addition to some performance improvements, the biggest addition is the introduction of a half-step state  when assaulting positions in the group memory. This prevents the issue where the AI would sometimes have trouble pathing inside buildings, particularly second floors, when at a distance from the target building. The advantage is simple: The AI will actually move more actively. Also a very rare occurrence of "shooting into air" has been mitigated.

Group actions: The Garrison state has been removed from the potential pool of tactics when clearing nearby buildings. It didn't work as intended, and rarely had a good gameplay effect of challenging players.