### PR TITLE
Update fnc_doUGL.sqf

### DIFF
--- a/addons/main/functions/UnitAction/fnc_doUGL.sqf
+++ b/addons/main/functions/UnitAction/fnc_doUGL.sqf
@@ -48,7 +48,7 @@ private _unit = _units findIf {
                 private _index = _findFlares findIf {
                     private _ammo = getText (configfile >> "CfgMagazines" >> _x >> "Ammo");
                     private _flareSimulation = getText (configfile >> "CfgAmmo" >> _ammo >> "simulation");
-                    _flareSimulation isEqualTo _type
+                    (_flareSimulation find _type) isNotEqualTo -1
                 };
 
                 if (_index == -1) exitWith {false};


### PR DESCRIPTION
More flexible sorting of 40mm rounds. Allows for a very common modification that makes smoke grenades less bouncy. (previously LAMBS Danger would not recognize these 40mm as 40mm)