### PR TITLE
Update fnc_doCallout

### DIFF
--- a/addons/main/functions/fnc_doCallout.sqf
+++ b/addons/main/functions/fnc_doCallout.sqf
@@ -82,9 +82,6 @@ if (isNil "_cachedSounds") then {
             if (_sound select [0, 1] != "\") then {
                 _sound = (getArray (configFile >> "CfgVoice" >> _speaker >> "directories") select 0) + _sound;
             };
-            if (_sound select [0, 1] == "\") then {
-                _sound = _sound select [1];
-            };
         };
         _cachedSounds set [_forEachIndex, _sound];
     } forEach _cachedSounds;

--- a/addons/main/functions/fnc_doCallout.sqf
+++ b/addons/main/functions/fnc_doCallout.sqf
@@ -104,7 +104,7 @@ if (_cachedSounds isEqualTo []) exitWith {
 };
 
 private _sound = selectRandom _cachedSounds;
-playSound3D [_sound, _unit, isNull (objectParent _unit), getPosASL _unit, 5, pitch _unit, _distance];
+playSound3D [_sound, _unit, isNull (objectParent _unit), eyePos _unit, 5, pitch _unit, _distance];
 [_unit, true] remoteExecCall ["setRandomLip", 0];
 [{
     _this remoteExecCall ["setRandomLip", 0];


### PR DESCRIPTION
### When merged this pull request will: Improve ``fnc_doCallout``

1. *Describe what this pull request will do*

Remove some obsolete code and makes sound originate roughly from the unit's face. Improves caching performance and makes the callout a bit more realistic with zero performance penalty.

Edit: The leading slash can be removed because since Arma 3 v2.10 ``playSound3D`` simply ignores the slash so it doesn't need to be manually removed. [Source: Biki](https://community.bistudio.com/wiki/playSound3D)

2. *Each change in a separate line*

- Remove obsolete code (since Arma 3 v2.10) from caching logic

- Make callout sound originate from unit's ``eyePos`` instead of their position
