### PR TITLE
Update isNight

### DIFF
--- a/addons/main/functions/fnc_isNight.sqf
+++ b/addons/main/functions/fnc_isNight.sqf
@@ -23,4 +23,5 @@ if (behaviour _unit isEqualTo "STEALTH"
 ) exitWith {false};
 
 // night check
-(getPos _unit) getEnvSoundController "night" isEqualTo 1
+// ~65 is the light level where vanilla AI puts nightvision goggles on
+(getLighting # 1) < 65


### PR DESCRIPTION
### When merged this pull request will: Utilise ``getLighting`` to check if it's night

1. *Describe what this pull request will do*

Utilise ``getLighting`` so the night check is based off of the amount of light instead of a soundcontroller. This might be an important distinction in cases where the night is really bright, due to midnight sun or the full moon.

~65 is the approximate light level where AI uses nightvision. Tested on Stratis (2035/07/06 YYYY/MM/DD) with vanilla AI.

2. *Each change in a separate line*

- Switch ``getEnvSoundController`` to ``getLighting``
