### PR TITLE
Optimize door finding in findBuildings

### DIFF
--- a/addons/main/functions/fnc_findBuildings.sqf
+++ b/addons/main/functions/fnc_findBuildings.sqf
@@ -37,8 +37,9 @@ private _housePos = [];
     _housePos append (_house buildingPos -1);
     if (_findDoors) then {
         {
+            if !("door" in _x) then {continue};
             _housePos pushBack (_house modelToWorld (_house selectionPosition _x));
-        } forEach ((_house selectionNames "viewgeometry") select {"door" in _x});
+        } forEach (_house selectionNames "viewgeometry");
     };
 } forEach _houses;
 

--- a/addons/main/functions/fnc_findBuildings.sqf
+++ b/addons/main/functions/fnc_findBuildings.sqf
@@ -37,8 +37,9 @@ private _housePos = [];
     _housePos append (_house buildingPos -1);
     if (_findDoors) then {
         {
-            if !("door" in _x) then {continue};
-            _housePos pushBack (_house modelToWorld (_house selectionPosition _x));
+            if ("door" in _x) then {
+                _housePos pushBack (_house modelToWorld (_house selectionPosition _x));
+            };
         } forEach (_house selectionNames "viewgeometry");
     };
 } forEach _houses;

--- a/addons/main/functions/fnc_findBuildings.sqf
+++ b/addons/main/functions/fnc_findBuildings.sqf
@@ -37,10 +37,8 @@ private _housePos = [];
     _housePos append (_house buildingPos -1);
     if (_findDoors) then {
         {
-            if ("door" in toLower (_x)) then {
-                _housePos pushBack (_house modelToWorld (_house selectionPosition _x));
-            };
-        } forEach (selectionNames _house);
+            _housePos pushBack (_house modelToWorld (_house selectionPosition _x));
+        } forEach ((_house selectionNames "viewgeometry") select {"door" in _x});
     };
 } forEach _houses;
 


### PR DESCRIPTION
### When merged this pull request will: Optimize the door finding logic

1. *Describe what this pull request will do*

Find doors faster by searching for the doors in ``viewGeometry`` ~~and using ``select`` to run the string filtering in-engine.~~

We can assume that doors are found in ``viewGeometry`` because this LOD is used for vision occlusion, which of course includes doors.

This new method is approximately ~4 times faster.

This also coincidentally fixes an issue where the same door positions get detected multiple times due to multiple selections having the same position, things like ``door_1`` and ``door_1_handle``.

``toLower`` is not necessary because all selections must be named lowercase.

Tested on random buildings on: Stratis, Livonia, Takistan, Chernarus, Lythium

**Further testing is encouraged!**

2. *Each change in a separate line*

- Remove ``toLower`` ~~and separate condition for string filtering, replaced with in-engine loop using ``select`` that doesn't use ``toLower``~~ because we can assume that selections are named lowercase

- Search for selections in ``viewGeometry`` because we can assume that doors are found there