### PR TITLE
Improve building filtering

### DIFF
--- a/addons/main/functions/fnc_findBuildings.sqf
+++ b/addons/main/functions/fnc_findBuildings.sqf
@@ -27,7 +27,7 @@ params [
 
 // houses
 private _houses = nearestObjects [_unit, ["House", "Strategic", "Ruins"], _range, true];
-_houses = _houses select {((_x buildingPos -1) isNotEqualTo [])};
+_houses = _houses select {((_x buildingPos -1) isNotEqualTo []) && {(alive _x) && !(isObjectHidden _x)}};
 
 // find house positions
 if (!_useHousePos) exitWith {_houses}; // return if not use House Pos


### PR DESCRIPTION
### When merged this pull request will: Add new conditions to building filtering in ``fnc_findBuildings``

1. *Describe what this pull request will do*
- Add two new conditions to the building filter: alive check and hidden check
- Alive check because when buildings get destroyed in Arma, the old building disappears and a ruin is spawned on top, so technically there are now two buildings. The invisible "dead" building and the newly spawned ruin version of the building. The ruin cannot "die" so this will simply filter out the "ghost" building.
- Hidden check because in rare circumstances mission makers might hide buildings, and we don't want to care about those.
2. *Each change in a separate line*
- Add alive check to remove unnecessary "ghost" buildings from the array
- Add hidden check to remove invisible buildings from the array
