### PR TITLE
fnc_findReadyVehicles ammo check

### DIFF
--- a/addons/main/functions/fnc_findReadyVehicles.sqf
+++ b/addons/main/functions/fnc_findReadyVehicles.sqf
@@ -25,6 +25,7 @@ private _vehicles = (units _unit) select {
     (_unit distance2D _x) < _range
     && { !(isNull objectParent _x) }
     && { canFire vehicle _x }
+    && { (magazines vehicle _x) isNotEqualTo [] }
     && { isTouchingGround vehicle _x }
 };
 


### PR DESCRIPTION
### When merged this pull request will: Ensure that vehicles aren't considered ready if they don't have any ammo

1. *Describe what this pull request will do*
- Add a magazine check to ``fnc_findReadyVehicles`` to see if the vehicle has any ammo left
- This is because ``canFire`` does not check for ammo
2. *Each change in a separate line*
- Add a magazine check to ``fnc_findReadyVehicles`` to see if the vehicle has any ammo left
