### PR TITLE
Change evaluation order in queue check

### DIFF
--- a/addons/danger/scripts/lambs_danger.fsm
+++ b/addons/danger/scripts/lambs_danger.fsm
@@ -531,7 +531,7 @@ class FSM
                                         priority = 4.000000;
                                         to="End_Forced";
                                         precondition = /*%FSM<CONDPRECONDITION""">*/""/*%FSM</CONDPRECONDITION""">*/;
-                                        condition=/*%FSM<CONDITION""">*/"call lambs_danger_fnc_isForced && {_queue isEqualTo []}"/*%FSM</CONDITION""">*/;
+                                        condition=/*%FSM<CONDITION""">*/"_queue isEqualTo [] && {call lambs_danger_fnc_isForced}"/*%FSM</CONDITION""">*/;
                                         action=/*%FSM<ACTION""">*/""/*%FSM</ACTION""">*/;
                                 };
                                 /*%FSM</LINK>*/


### PR DESCRIPTION
### When merged this pull request will: Slightly optimize queue checking in the danger.fsm

1. *Describe what this pull request will do*
Optimize queue checking by changing the evaluation order to reduce function calls

2. *Each change in a separate line*
- Check queue size before calling ``lambs_danger_fnc_isForced``
