### PR TITLE
WIP: Improve doCover logic

### DIFF
--- a/addons/danger/functions/fnc_brainReact.sqf
+++ b/addons/danger/functions/fnc_brainReact.sqf
@@ -33,15 +33,15 @@ private _timeout = time + 1.4;
 // ACE3
 _unit setVariable ["ace_medical_ai_lastHit", CBA_missionTime];
 
-// cover move when explosion
+// Move to cover if it's relatively safe
 if (
-    getSuppression _unit < 0.6
+    getSuppression _unit < 0.4
+    && {RND(0.67)} // Add some randomness so they aren't taking cover all the time
     && {(speed _unit) isEqualTo 0}
-    && {_type in [DANGER_EXPLOSION, DANGER_FIRE]}
+    && {!(_unit call EFUNC(main,isIndoor))} // Don't try anything indoors
 ) exitWith {
-    _unit setUnitPosWeak "DOWN";
-    [_unit] call EFUNC(main,doCover);
-    _timeout + 1
+    [_unit, _pos] call EFUNC(main,doCover);
+    _timeout + 2
 };
 
 // dodge!

--- a/addons/main/functions/UnitAction/fnc_doCover.sqf
+++ b/addons/main/functions/UnitAction/fnc_doCover.sqf
@@ -1,50 +1,63 @@
 #include "script_component.hpp"
 /*
  * Author: nkenny
- * moved the unit into cover
+ * Unit tries to move into cover from danger
+ * Cover that is towards the enemy is prioritised,-
+ * so the unit will slowly advance if cover allows
  *
  * Arguments:
  * 0: unit doing the flight <OBJECT>
- * 1: position of cover <ARRAY>
+ * 1: position of danger <ARRAY>
  *
  * Return Value:
  * bool
  *
  * Example:
- * [bob] call lambs_main_fnc_doCover;
+ * [bob, getPosATL badguy] call lambs_main_fnc_doCover;
  *
  * Public: No
 */
-#define SEARCH_FOR_HIDE 6
+#define SEARCH_FOR_HIDE 6.5
 
-params ["_unit", ["_pos", [], [[]]]];
+params [
+    ["_unit", objNull, [objNull]],
+    ["_dangerPos", [0,0,0], [[]]]
+];
 
-// check if stopped
+if (isNull _unit || _dangerPos isEqualTo [0,0,0]) exitWith {false};
+if ((_unit distance2D _dangerPos) < 20) exitWith {false};
+if (!(_unit checkAIFeature "MOVE")) exitWith {false};
 if (!(_unit checkAIFeature "PATH")) exitWith {false};
 
-// find cover
-if (_pos isEqualTo []) then {
-    _pos = nearestTerrainObjects [_unit, ["BUSH", "TREE", "HIDE"], SEARCH_FOR_HIDE, true, true];
-    _pos = if (_pos isEqualTo []) then {
-        getPosASL _unit
-    } else {
-        (_pos select 0) getPos [-1.2, _unit getDir (_pos select 0)]
-    };
+// Take cover
+_unit setVariable [QGVAR(currentTask), "Take Cover!", GVAR(debug_functions)];
+
+// Drop stance
+if ((stance _unit) isEqualTo "STAND") then {_unit setUnitPosWeak "MIDDLE"};
+
+// find cover, preferably towards the opponent
+private _coverPositions = nearestTerrainObjects [_unit getPos [1.5, _unit getDir _dangerPos], ["BUSH", "TREE", "HIDE"], SEARCH_FOR_HIDE, true, true];
+
+private _pos = if (_coverPositions isEqualTo []) then {
+    getPosATL _unit
+} else {
+    private _cover = _coverPositions select 0;
+    _cover getPos [2, _dangerPos getDir _cover]
 };
 
 // force anim
 if (_unit distance2D _pos < 0.6) exitWith {false};
 private _direction = _unit getRelDir _pos;
 private _anim = call {
-    if (_direction > 315) exitWith {["WalkF", "WalkLF"]};
-    if (_direction > 225) exitWith {["WalkL", "WalkLF"]};
-    if (_direction > 135) exitWith {["WalkB"]};
-    if (_direction > 45) exitWith {["WalkR", "WalRF"]};
-    ["WalkF", "WalkRF"]
+    if (_direction > 315) exitWith {["FastF", "FastLF"]};
+    if (_direction > 225) exitWith {["FastL", "FastLF"]};
+    if (_direction > 135) exitWith {["FastB"]};
+    if (_direction > 45) exitWith {["FastR", "FastRF"]};
+    ["FastF", "FastRF"]
 };
 
 // prevent run in place
-_unit moveTo _pos;
+_unit doMove _pos;
 _unit setDestination [_pos, "FORMATION PLANNED", true];
 
 // do anim


### PR DESCRIPTION
### When merged this pull request will: Make doCover activate for all danger sources and make it consider the direction of the danger.

1. *Describe what this pull request will do*
Hopefully make firefights more dynamic by having the AI actually attempt to use cover by occasionally dashing behind soft- and hard cover, slightly biased towards the enemy so it'll "advance" towards the enemy.

2. *Each change in a separate line*
- doCover might now activate for all sources of danger, including gunfire
- doCover now takes into account the direction of the danger to make units hide behind trees, rocks, etc
- doCover now has a slight bias for cover in front of the unit, so it might "advance" towards the enemy

I've declared this a draft, because I am not sure if this fits into lambs. It's pretty nice watching the AI now take cover, but I can see some issues, such as formations breaking, units wandering off, moving between two pieces of cover unnecessarily, etc. So, discussion is very much welcome.