### PR TITLE
Fix issues relating to constant dismounts

### DIFF
--- a/addons/danger/XEH_preInit.sqf
+++ b/addons/danger/XEH_preInit.sqf
@@ -32,18 +32,24 @@ if (isNil QGVAR(dangerUntil)) then {
 // EH handling reinforcement and combat mode
 [QEGVAR(main,OnInformationShared), {
     params [["_unit", objNull], "", ["_target", objNull], ["_groups", []]];
-
     {
         private _leader = leader _x;
         if (local _leader) then {
             // reinforce
-            if (!isNull _target && { _x getVariable [QGVAR(enableGroupReinforce), false] } && { (_x getVariable [QGVAR(enableGroupReinforceTime), -1]) < time }) then {
+            if (
+                !isNull _target
+                && {_x getVariable [QGVAR(enableGroupReinforce), false]}
+                && {(_x getVariable [QGVAR(enableGroupReinforceTime), -1]) < time }
+            ) then {
                 [_leader, [getPosASL _unit, (_leader targetKnowledge _target) select 6] select (_leader knowsAbout _target > 1.5)] call FUNC(tacticsReinforce);
             };
 
-            // set combatMode
-            if (_leader distance2D _unit < (EGVAR(main,combatShareRange)) && {!(_leader getVariable [QGVAR(disableAI), false])} && {(behaviour _leader) isNotEqualTo "COMBAT"}) then {
-                [units _x, _target, [_leader, 40, true, true] call EFUNC(main,findBuildings), "information"] call EFUNC(main,doGroupHide);
+            // reorientate group
+            if (
+                !(_leader getVariable [QGVAR(disableAI), false])
+                && {(behaviour _leader) isNotEqualTo "COMBAT"}
+            ) then {
+                //[units _x, _target, [_leader, 40, true, true] call EFUNC(main,findBuildings), "information"] call EFUNC(main,doGroupHide);
                 _x setFormDir (_leader getDir _unit);
             };
         };

--- a/addons/main/functions/UnitAction/fnc_doFleeing.sqf
+++ b/addons/main/functions/UnitAction/fnc_doFleeing.sqf
@@ -14,7 +14,7 @@
  *
  * Public: No
 */
-#define SEARCH_FOR_HIDE 4
+#define SEARCH_FOR_HIDE 6
 #define SEARCH_FOR_BUILDING 8
 
 params ["_unit"];
@@ -39,12 +39,14 @@ _unit setVariable [QGVAR(currentTarget), objNull, GVAR(debug_functions)];
 [QGVAR(OnFleeing), [_unit, group _unit]] call FUNC(eventCallback);
 
 // Abandon vehicles in need!
+private _vehicle = vehicle _unit;
 if (
     RND(0.5)
     && {!_onFoot}
-    && {canUnloadInCombat (vehicle _unit)}
-    && {(speed (vehicle _unit)) < 3}
-    && {isTouchingGround vehicle _unit}
+    && {morale _unit < 0}
+    && {canUnloadInCombat _vehicle || {_vehicle isKindOf "StaticWeapon"}}
+    && {(speed _vehicle) < 3}
+    && {isTouchingGround _vehicle}
 ) exitWith {
     [_unit] orderGetIn false;
     _unit setSuppression 1;  // prevents instant laser aim - nkenny
@@ -80,7 +82,7 @@ if (_onFootAndSeen) then {
     };
 
     // calm and inside or under cover!
-    if ((_suppression < 0.2) && {lineIntersects [_eyePos, _eyePos vectorAdd [0, 0, 10], _unit] || {_distance2D < random 5}}) exitWith {
+    if ((_suppression < 0.2) && {lineIntersects [_eyePos, _eyePos vectorAdd [0, 0, 10], _unit] || {_distance2D < 15}}) exitWith {
         _unit setUnitPos "DOWN";// ~ this forces unit stance which may override mission maker. The effect is good however - nkenny
         doStop _unit;
     };
@@ -94,12 +96,13 @@ if (_onFootAndSeen) then {
 
     // find buildings to hide
     private _buildings = [_unit, SEARCH_FOR_BUILDING, true, true] call FUNC(findBuildings);
-    if ((_buildings isNotEqualTo []) && {_distance2D > random 5}) then {
+    _buildings append (_cover apply {getPos _x});
+    if ((_buildings isNotEqualTo []) && {_distance2D > 5}) then {
         _unit doMove selectRandom _buildings;
     };
 
 } else {
-    // follow self! ~ bugfix which prevents untis from getting stuck in fleeing loop inside fsm. - nkenny
+    // follow self! ~ bugfix which prevents units from getting stuck in fleeing loop inside fsm. - nkenny
     _unit doFollow (leader _unit);
 
     // reset

--- a/addons/main/functions/UnitAction/fnc_doHide.sqf
+++ b/addons/main/functions/UnitAction/fnc_doHide.sqf
@@ -65,19 +65,20 @@ if (RND(0.1) && { _buildings isNotEqualTo [] }) exitWith {
 _unit setUnitPosWeak "DOWN";
 
 // check for rear-cover
-private _cover = nearestTerrainObjects [ _unit getPos [1, getDir _unit], ["BUSH", "TREE", "SMALL TREE", "HIDE", "ROCK", "WALL", "FENCE"], 9, true, true ];
+private _cover = nearestTerrainObjects [ _unit getPos [1, getDir _unit], ["BUSH", "TREE", "SMALL TREE", "HIDE", "ROCK", "WALL", "FENCE"], 15, true, true ];
 
 // targetPos
 private _targetPos = if (_cover isEqualTo []) then {
     _unit getPos [10 + random _range, (_pos getDir _unit) + 45 - random 90]
 } else {
-    (_cover select 0) getPos [-1.2, _unit getDir (_cover select 0)]
+    (_cover select 0) getPos [-0.6, _unit getDir (_cover select 0)]
 };
 
 // water means hold
 if (surfaceIsWater _targetPos) then {_targetPos = getPosATL _unit;};
 
 // cover move
+doStop _unit;
 _unit doMove _targetPos;
 
 // debug

--- a/addons/main/functions/fnc_doShareInformation.sqf
+++ b/addons/main/functions/fnc_doShareInformation.sqf
@@ -64,7 +64,7 @@ if !(isNull _target) then {
     private _knowsAbout = (_unit knowsAbout _target) min GVAR(maxRevealValue);
     {
         [_x, [_target, _knowsAbout]] remoteExec ["reveal", leader _x];
-    } forEach _groups;
+    } forEach (_groups select {_unit distance2D (leader _x) < GVAR(combatShareRange)});
 };
 
 [QGVAR(OnInformationShared), [_unit, group _unit, _target, _groups]] call FUNC(eventCallback);
@@ -81,17 +81,20 @@ if (
 // debug
 if (EGVAR(main,debug_functions)) then {
     // debug message
-    ["%1 share information (%2 knows %3 to %4 groups @ %5m range)", side _unit, name _unit, (_unit knowsAbout _target) min 1, count _groups, round _range] call FUNC(debugLog);
+    ["%1 share information (%2 knows %3 to %4 groups @ %5m range)", side _unit, name _unit, (_unit knowsAbout _target) min GVAR(maxRevealValue), count _groups, round _range] call FUNC(debugLog);
 
     // debug marker
-    private _zm = [_unit, [_range,_range], _unit call FUNC(debugMarkerColor), "Border"] call FUNC(zoneMarker);
-    private _markers = [_zm];
+    private _zm = [_unit, [_range, _range], _unit call FUNC(debugMarkerColor), "Border"] call FUNC(zoneMarker);
+    private _zmm = [_unit, [_range min GVAR(combatShareRange), _range min GVAR(combatShareRange)], _unit call FUNC(debugMarkerColor), "SolidBorder"] call FUNC(zoneMarker);
+    _zmm setMarkerAlphaLocal 0.3;
+    private _markers = [_zm, _zmm];
 
     // enemy units
     {
         private _m = [_unit getHideFrom _x, "", _x call FUNC(debugMarkerColor), "mil_triangle"] call FUNC(dotMarker);
         _m setMarkerSizeLocal [0.5, 0.5];
         _m setMarkerDirLocal (getDir _x);
+        _m setMarkerTextLocal str (_unit knowsAbout _x);
         _markers pushBack _m;
     } foreach ((units _target) select {_unit knowsAbout _x > 0});
 

--- a/addons/main/functions/fnc_getShareInformationParams.sqf
+++ b/addons/main/functions/fnc_getShareInformationParams.sqf
@@ -38,10 +38,10 @@ private _units = units _unit select {
     && {_x call FUNC(isAlive)}
 };
 private _index = _units findIf {
-        _x getVariable [QEGVAR(danger,dangerRadio), false]
-        || {(!isNull objectParent _x && {_x distance2D _unit < 70})}
-        || {"b_radiobag_01_" in (toLower backpack _x)}
-        || {(getNumber (configFile >> "CfgVehicles" >> (backpack _x) >> "tf_hasLRradio")) isEqualTo 1}
+    _x getVariable [QEGVAR(danger,dangerRadio), false]
+    //|| {(!isNull objectParent _x && {_x distance2D _unit < 70})}
+    || {"b_radiobag_01_" in (toLower backpack _x)}
+    || {(getNumber (configFile >> "CfgVehicles" >> (backpack _x) >> "tf_hasLRradio")) isEqualTo 1}
 };
 _radio = _index isNotEqualTo -1;
 if (_radio) then {


### PR DESCRIPTION
This patches some of the issues pertaining to constant dismounting of units. 

It does this by rethinking how information is shared, and fixing a bug in doFleeing (which would not take into account the units current situation very well). Information is now only passed for units that are within "combatShareRange"  ~ 200 meters by default.  Units outside this distance, but within radio range, will unless busy, instead turn towards the direction of the unit calling for aid. 

Hiding is also tweaked to make that contact response more effective, which again translates into fewer repetitive executions of said command. 