### PR TITLE
Check callout validity

### DIFF
--- a/addons/main/functions/fnc_doCallout.sqf
+++ b/addons/main/functions/fnc_doCallout.sqf
@@ -103,7 +103,17 @@ if (_cachedSounds isEqualTo []) exitWith {
     };
 };
 
+// Not a valid file to play, extension must be included
 private _sound = selectRandom _cachedSounds;
+if !(".ogg" in _sound || ".wss" in _sound || ".wav" in _sound) exitWith {
+    if (GVAR(debug_functions)) then {
+        private _str = "WARNING: Callout file path %1 for callout %2 for speaker %3 is not valid!";
+        private _arr = [_str, _sound, _callout, _speaker];
+        _arr call FUNC(debugLog);
+        _arr call BIS_fnc_error;
+    };
+};
+
 playSound3D [_sound, _unit, isNull (objectParent _unit), eyePos _unit, 5, pitch _unit, _distance];
 [_unit, true] remoteExecCall ["setRandomLip", 0];
 [{

--- a/addons/main/functions/fnc_doCallout.sqf
+++ b/addons/main/functions/fnc_doCallout.sqf
@@ -77,13 +77,13 @@ if (isNil "_cachedSounds") then {
         private _sound = toLowerANSI _x; // playSound3D is case-insensitive
 
         // File extension must exist for playSound3D to work
-        if (_sound == "" || !(".ogg" in _sound || ".wss" in _sound || ".wav" in _sound)) then {
-            _sound = objNull;
-            _deleted = true;
-        } else {
+        if (_sound regexMatch ".+?\.(?:ogg|wss|wav|mp3)$/io") then {
             if (_sound select [0, 1] != "\") then {
                 _sound = (getArray (configFile >> "CfgVoice" >> _speaker >> "directories") select 0) + _sound;
             };
+        } else {
+            _sound = objNull;
+            _deleted = true;
         };
 
         _cachedSounds set [_forEachIndex, _sound];

--- a/addons/main/functions/fnc_doCallout.sqf
+++ b/addons/main/functions/fnc_doCallout.sqf
@@ -74,8 +74,10 @@ if (isNil "_cachedSounds") then {
     _cachedSounds = getArray (_protocolConfig >> _callout);
     private _deleted = false;
     {
-        private _sound = _x;
-        if (_sound == "") then {
+        private _sound = toLowerANSI _x; // playSound3D is case-insensitive
+
+        // File extension must exist for playSound3D to work
+        if (_sound == "" || !(".ogg" in _sound || ".wss" in _sound || ".wav" in _sound)) then {
             _sound = objNull;
             _deleted = true;
         } else {
@@ -83,6 +85,7 @@ if (isNil "_cachedSounds") then {
                 _sound = (getArray (configFile >> "CfgVoice" >> _speaker >> "directories") select 0) + _sound;
             };
         };
+
         _cachedSounds set [_forEachIndex, _sound];
     } forEach _cachedSounds;
 
@@ -103,17 +106,7 @@ if (_cachedSounds isEqualTo []) exitWith {
     };
 };
 
-// Not a valid file to play, extension must be included
 private _sound = selectRandom _cachedSounds;
-if !(".ogg" in _sound || ".wss" in _sound || ".wav" in _sound) exitWith {
-    if (GVAR(debug_functions)) then {
-        private _str = "WARNING: Callout file path %1 for callout %2 for speaker %3 is not valid!";
-        private _arr = [_str, _sound, _callout, _speaker];
-        _arr call FUNC(debugLog);
-        _arr call BIS_fnc_error;
-    };
-};
-
 playSound3D [_sound, _unit, isNull (objectParent _unit), eyePos _unit, 5, pitch _unit, _distance];
 [_unit, true] remoteExecCall ["setRandomLip", 0];
 [{


### PR DESCRIPTION
### When merged this pull request will: Title

1. *Describe what this pull request will do*
Check that callouts are valid when caching them.
Negligible performance degradation to caching logic (``~0.0012ms`` per check) but overall positive performance impact once cache is made.
This should remove all log errors relating to invalid files, e.g:
``Sound: Error: File: rhsafrf\addons\rhs_s_radio\radio\Male01\RU\Advance not found !!!``

2. *Each change in a separate line*
- Check that callout sounds have file extensions when caching them