### PR TITLE
Update fnc_getCompatibleThrowMuzzle.sqf

### DIFF
--- a/addons/main/functions/fnc_getCompatibleThrowMuzzle.sqf
+++ b/addons/main/functions/fnc_getCompatibleThrowMuzzle.sqf
@@ -31,10 +31,10 @@ private _muzzleIdx = GVAR(cachedThrowingWeapons) findIf {
     _magazine in _compatible
 };
 
-if (_muzzleIdx == -1) then {    
+if (_muzzleIdx == -1) then {
     _muzzle = "";
 } else {
-    _muzzle = GVAR(cachedThrowingWeapons) select _muzzleIdx;
+    _muzzle = configName (GVAR(cachedThrowingWeapons) select _muzzleIdx);
 };
 
 GVAR(cachedThrowingWeaponsHash) set [_magazine, _muzzle];


### PR DESCRIPTION
Failed to return useful string. Fixed in this pull request

Quickfix. Should push a new dev branch soon.tm