### PR TITLE
Fixes doGroupStaticPack

### DIFF
--- a/addons/main/functions/GroupAction/fnc_doGroupStaticPack.sqf
+++ b/addons/main/functions/GroupAction/fnc_doGroupStaticPack.sqf
@@ -33,7 +33,7 @@ if (_guns isEqualTo []) then {
 };
 
 // check if weapon is unmanned
-_guns = _guns select {alive _x && {_x isKindOf "StaticWeapon"} && ((crew _x) isNotEqualTo [])};
+_guns = _guns select {alive _x && {(vehicle _x) isKindOf "StaticWeapon"} && ((crew _x) isNotEqualTo [])};
 if (_guns isEqualTo []) exitWith { _units };
 
 // get gunner
@@ -79,7 +79,7 @@ _assistant setUnitPosWeak "MIDDLE";
 _assistant forceSpeed 24;
 _assistant setVariable [QEGVAR(danger,forceMove), true];
 _assistant setVariable [QGVAR(currentTask), "Pack Static Weapon", GVAR(debug_functions)];
-_assistant setVariable [QGVAR(currentTarget), getPos _gunner, GVAR(debug_functions)];
+_assistant setVariable [QGVAR(currentTarget), POSITIONAGL(_gunner), GVAR(debug_functions)];
 _assistant doMove getPosATL (vehicle _gunner);
 
 // do it


### PR DESCRIPTION
The function failed to pack weapons in some cases. Now it always packs. 

Relies on #341 