### PR TITLE
Add features to fnc_tacticsReinforce.sqf

### DIFF
--- a/addons/danger/functions/fnc_tacticsReinforce.sqf
+++ b/addons/danger/functions/fnc_tacticsReinforce.sqf
@@ -81,7 +81,7 @@ private _assignedVehicles = assignedVehicles _group;
 if (_assignedVehicles isEqualTo []) then {
     private _vehicles = nearestObjects [_unit, ["Landvehicle"], 75];
     private _side = getNumber (configOf _unit >> "side");
-    _vehicles = _vehicles select {alive _x && canMove _x && simulationEnabled _x && {(crew _x) isEqualTo []} && { !isObjectHidden _x } && { locked _x != 2 } && {(getNumber (configOf _unit >> "side")) isEqualTo _side}};
+    _vehicles = _vehicles select {alive _x && canMove _x && simulationEnabled _x && {(crew _x) isEqualTo []} && { !isObjectHidden _x } && { locked _x != 2 } && {(getNumber (configOf _x >> "side")) isEqualTo _side}};
     if (_vehicles isNotEqualTo []) then {
         {
             _group addVehicle _x;

--- a/addons/danger/functions/fnc_tacticsReinforce.sqf
+++ b/addons/danger/functions/fnc_tacticsReinforce.sqf
@@ -25,7 +25,7 @@ if (!(_unit call EFUNC(main,isAlive))) exitWith {false};
 // free garrisons
 private _group = group _unit;
 if (EGVAR(main,Loaded_WP) && {!(_unit checkAIFeature "PATH")}) then {
-    _group = [_group, true] call EFUNC(wp,taskReset);
+    _group = [_group, true, true] call EFUNC(wp,taskReset);
 };
 
 // set new time
@@ -42,7 +42,7 @@ _group setVariable [QEGVAR(main,currentTactic), "Reinforcing", EGVAR(main,debug_
 _group setVariable [QGVAR(isExecutingTactic), true];
 _group setVariable [QGVAR(contact), time + _delay];
 _group enableAttack false;      // gives better fine control of AI - nkenny
-_group setBehaviour "AWARE";    // more tractacle speed
+_group setBehaviour "AWARE";    // more tractable speed
 
 // reset
 [
@@ -69,30 +69,64 @@ if (_units isEqualTo []) then {
     _units = units _unit;
 };
 
+// set waiting time for movement order
+private _waitForMove = 5;
+
+// get vehicles
+private _assignedVehicles = assignedVehicles _group;
+
 // check waypoints -- if none add new?
 // commander vehicles? ~ future versions with setting ~ nkenny
+private _vehicles = nearestObjects [_unit, ["Landvehicle"], 75];
+private _side = getNumber (configFile >> "CfgVehicles" >> (typeOf _unit) >> "side");
+_vehicles = _vehicles select {alive _x && canMove _x && simulationEnabled _x && {(crew _x) isEqualTo []} && { !isObjectHidden _x } && { locked _x != 2 } && {(getNumber (configFile >> "CfgVehicles" >> (typeOf _x) >> "side")) isEqualTo _side}};
+if (_vehicles isNotEqualTo []) then {
+    {
+        _group addVehicle _x;
+        _waitForMove = _waitForMove + 2;
+    } forEach _vehicles;
+};
+
+// check for unregistered static weapons
+private _guns = _units select {(vehicle _x) isKindOf "StaticWeapon"};
+if ((_group getVariable [QEGVAR(main,staticWeaponList), []]) isEqualTo []) then {
+    _group setVariable [QEGVAR(main,staticWeaponList), _guns, true];
+    _waitForMove = _waitForMove + 1;
+};
+
+// check bodies
+private _weaponHolders = allDeadMen findIf { (_x distance2D _unit) < 35 };
+if (_weaponHolders isNotEqualTo -1) then {
+    {
+        [{_this call lambs_main_fnc_doCheckBody;}, [_x, _x getPos [20, random 360], 35], random 2] call CBA_fnc_waitAndExecute;
+        _waitForMove = _waitForMove + 2;
+    } forEach _units;
+};
+
 // has artillery? ~ if so fire in support?
 // is aircraft or tank? Different movement waypoint?
 
-// clear HOLD waypointss
+// clear HOLD, GUARD and DISMISS waypoints
 private _waypoints = waypoints _group;
-private _currentWP = _waypoints select ((currentWaypoint _group) min ((count _waypoints) - 1));
-if ((waypointType _currentWP) isEqualTo "HOLD") then {
-    [_group] call CBA_fnc_clearWaypoints;
+if (_waypoints isNotEqualTo []) then {
+    private _currentWP = _waypoints select ((currentWaypoint _group) min ((count _waypoints) - 1));
+    if ((waypointType _currentWP) in ["HOLD", "GUARD", "DISMISS"]) then {
+        [_group] call CBA_fnc_clearWaypoints;
+    };
 };
 
 // formation changes ~ allowed here as Reinforcing units have full autonomy - nkenny
 private _distance = _unit distance2D _target;
 if (_distance > 500) then {
-    _unit setFormation "COLUMN";
+    _group setFormation selectRandom ["COLUMN", "STAG COLUMN"];
     if !(isNull objectParent _unit) then {(vehicle _unit) setUnloadInCombat [false, false];};
 } else {
     if (_distance > 200) then {
-        _unit setFormation selectRandom ["WEDGE", "VEE", "LINE"];
+        _group setFormation selectRandom ["WEDGE", "VEE", "LINE"];
     };
     if (_distance < GVAR(cqbRange)) then {
-        _unit setFormation "FILE";
-        [_unit, _target] call FUNC(tacticsAssault);
+        // _group setFormation "FILE"; ~formation is set in tacticsAssault ~KRM
+        [_group, _target] call FUNC(tacticsAssault);
     };
 };
 
@@ -100,10 +134,10 @@ if (_distance > 500) then {
 if !(GVAR(disableAIDeployStaticWeapons)) then {
     private _intersect = terrainIntersectASL [eyePos _unit, AGLtoASL (_target vectorAdd [0, 0, 10])];
     if (_distance > 400 || {_intersect}) then {
-        _units = [_units] call EFUNC(main,doGroupStaticPack);
+        _units = [leader _group] call EFUNC(main,doGroupStaticPack);
     };
     if (!_intersect) then {
-        _units = [_units, _target] call EFUNC(main,doGroupStaticDeploy);
+        _units = [leader _group, _target] call EFUNC(main,doGroupStaticDeploy);
     };
 };
 
@@ -119,7 +153,7 @@ if (!(GVAR(disableAutonomousFlares)) && {_unit call EFUNC(main,isNight)}) then {
         _group move _target;
     },
     [_group, _target],
-    5
+    _waitForMove
 ] call CBA_fnc_waitAndExecute;
 
 // debug
@@ -128,7 +162,7 @@ if (EGVAR(main,debug_functions)) then {
         "%1 TACTICS REINFORCING (%2 with %3 units @ %4m)",
         side _unit,
         name _unit,
-        count _units,
+        count units _group,
         round (_unit distance2D _target)
     ] call EFUNC(main,debugLog);
     private _m = [_unit, format ["Reinforcing @ %1m", round (_unit distance2D _target)], _unit call EFUNC(main,debugMarkerColor), "hd_warning"] call EFUNC(main,dotMarker);

--- a/addons/danger/functions/fnc_tacticsReinforce.sqf
+++ b/addons/danger/functions/fnc_tacticsReinforce.sqf
@@ -80,8 +80,8 @@ private _assignedVehicles = assignedVehicles _group;
 // commander vehicles? ~ future versions with setting ~ nkenny
 if (_assignedVehicles isEqualTo []) then {
     private _vehicles = nearestObjects [_unit, ["Landvehicle"], 75];
-    private _side = getNumber (configFile >> "CfgVehicles" >> (typeOf _unit) >> "side");
-    _vehicles = _vehicles select {alive _x && canMove _x && simulationEnabled _x && {(crew _x) isEqualTo []} && { !isObjectHidden _x } && { locked _x != 2 } && {(getNumber (configFile >> "CfgVehicles" >> (typeOf _x) >> "side")) isEqualTo _side}};
+    private _side = getNumber (configOf _unit >> "side");
+    _vehicles = _vehicles select {alive _x && canMove _x && simulationEnabled _x && {(crew _x) isEqualTo []} && { !isObjectHidden _x } && { locked _x != 2 } && {(getNumber (configOf _unit >> "side")) isEqualTo _side}};
     if (_vehicles isNotEqualTo []) then {
         {
             _group addVehicle _x;
@@ -102,7 +102,7 @@ if ((_group getVariable [QEGVAR(main,staticWeaponList), []]) isEqualTo []) then 
 private _weaponHolders = allDeadMen findIf { (_x distance2D _unit) < 35 };
 if (_weaponHolders isNotEqualTo -1) then {
     {
-        [{_this call lambs_main_fnc_doCheckBody;}, [_x, _x getPos [20, random 360], 35], random 2] call CBA_fnc_waitAndExecute;
+        [{_this call FUNC(main,doCheckBody);}, [_x, _x getPos [20, random 360], 35], random 2] call CBA_fnc_waitAndExecute;
         _waitForMove = _waitForMove + 2;
     } forEach _units;
 };

--- a/addons/danger/functions/fnc_tacticsReinforce.sqf
+++ b/addons/danger/functions/fnc_tacticsReinforce.sqf
@@ -76,16 +76,20 @@ private _waitForMove = 5;
 private _assignedVehicles = assignedVehicles _group;
 
 // check waypoints -- if none add new?
+
 // commander vehicles? ~ future versions with setting ~ nkenny
-private _vehicles = nearestObjects [_unit, ["Landvehicle"], 75];
-private _side = getNumber (configFile >> "CfgVehicles" >> (typeOf _unit) >> "side");
-_vehicles = _vehicles select {alive _x && canMove _x && simulationEnabled _x && {(crew _x) isEqualTo []} && { !isObjectHidden _x } && { locked _x != 2 } && {(getNumber (configFile >> "CfgVehicles" >> (typeOf _x) >> "side")) isEqualTo _side}};
-if (_vehicles isNotEqualTo []) then {
-    {
-        _group addVehicle _x;
-        _waitForMove = _waitForMove + 2;
-    } forEach _vehicles;
+if (_assignedVehicles isEqualTo []) then {
+    private _vehicles = nearestObjects [_unit, ["Landvehicle"], 75];
+    private _side = getNumber (configFile >> "CfgVehicles" >> (typeOf _unit) >> "side");
+    _vehicles = _vehicles select {alive _x && canMove _x && simulationEnabled _x && {(crew _x) isEqualTo []} && { !isObjectHidden _x } && { locked _x != 2 } && {(getNumber (configFile >> "CfgVehicles" >> (typeOf _x) >> "side")) isEqualTo _side}};
+    if (_vehicles isNotEqualTo []) then {
+        {
+            _group addVehicle _x;
+            _waitForMove = _waitForMove + 2;
+        } forEach _vehicles;
+    };
 };
+
 
 // check for unregistered static weapons
 private _guns = _units select {(vehicle _x) isKindOf "StaticWeapon"};

--- a/addons/danger/functions/fnc_tacticsReinforce.sqf
+++ b/addons/danger/functions/fnc_tacticsReinforce.sqf
@@ -102,7 +102,7 @@ if ((_group getVariable [QEGVAR(main,staticWeaponList), []]) isEqualTo []) then 
 private _weaponHolders = allDeadMen findIf { (_x distance2D _unit) < 35 };
 if (_weaponHolders isNotEqualTo -1) then {
     {
-        [{_this call FUNC(main,doCheckBody);}, [_x, _x getPos [20, random 360], 35], random 2] call CBA_fnc_waitAndExecute;
+        [{_this call EFUNC(main,doCheckBody);}, [_x, _x getPos [20, random 360], 35], random 2] call CBA_fnc_waitAndExecute;
         _waitForMove = _waitForMove + 2;
     } forEach _units;
 };


### PR DESCRIPTION
Adds new features to tacticsReinforce

Adds groups set to reinforce will appropriate vehicles (of their side) to use for transport
Adds groups will take ownership of static weapons (and pack them for their use)
Adds groups will check dead bodies for useful weapon before rienforcing
Improves more reliable packing and deploying of static weapons
Improves more formations used
Fixes "HOLD", "GUARD", and "DISMISS" waypoints not being cancelled

Overall this is a considerable enhancement to how units with the reinforcement flag function.  They will much more reliably collect nearby resources before moving to reinforce, and add considerable dynamic potential to operations
