### PR TITLE
Allows AI to target ACE3 incapacitated enemies in CQB

### DIFF
--- a/addons/danger/functions/fnc_brainEngage.sqf
+++ b/addons/danger/functions/fnc_brainEngage.sqf
@@ -50,6 +50,13 @@ if (
     && {(vehicle _target) isKindOf "CAManBase"}
     // && {_target call EFUNC(main,isAlive)}
 ) exitWith {
+
+    // set incapacitated ACE units visible
+    if (!GVAR(disableIncapacitatedKills)) then {
+        private _vis = _target getVariable ["ace_common_oldVisibility", 1];
+        if (_vis isEqualTo 0) then {_target setUnitTrait ["camouflageCoef", _vis];};
+    };
+
     _unit setVariable ["ace_medical_ai_lastFired", CBA_missionTime]; // ACE3
     [_unit, _target] call EFUNC(main,doAssault);
     _timeout + 1.4

--- a/addons/danger/settings.inc.sqf
+++ b/addons/danger/settings.inc.sqf
@@ -19,7 +19,7 @@ private _curCat = ELSTRING(main,Settings_MainCat);
     0
 ] call CBA_fnc_addSetting;
 
-// Toggles group manoevure phase initiated by AI squad leader
+// Toggles group manoeuvre phase initiated by AI squad leader
 [
     QGVAR(disableAIAutonomousManoeuvres),
     "CHECKBOX",
@@ -84,6 +84,15 @@ private _curCat = ELSTRING(main,Settings_MainCat);
     0
 ] call CBA_fnc_addSetting;
 
+// Toggles units killing ACE3 incapacitated enemies
+[
+    QGVAR(disableIncapacitatedKills),
+    "CHECKBOX",
+    [LSTRING(Settings_DisableIncapacitatedKills), LSTRING(Settings_DisableIncapacitatedKills_ToolTip)],
+    [COMPONENT_NAME, _curCat],
+    false,
+    1
+] call CBA_fnc_addSetting;
 
 private _curCat = LSTRING(Settings_GeneralCat);
 

--- a/addons/danger/stringtable.xml
+++ b/addons/danger/stringtable.xml
@@ -245,7 +245,7 @@
             <Chinesesimp>切换AI小组自动使用烟雾弹掩护小组的功能</Chinesesimp>
         </Key>
         <Key ID="STR_Lambs_Danger_Settings_DisableAutonomousFlares">
-            <English>Disable units using flares for illumination </English>
+            <English>Disable units using flares for illumination</English>
             <Czech>Vypíná schopnost jednotek používat světlice k osvětlení</Czech>
             <Polish>Wyłącz autonomiczne używanie flar przez AI</Polish>
             <Russian>Отключить способность ИИ использовать осветительные ракеты для освещения</Russian>
@@ -261,6 +261,12 @@
             <German>Schaltet die Fähigkeit der KI-Gruppe um, autonom Flares zur nächtlichen Beleuchtung zu verwenden, es sei denn, NVGs sind verfügbar oder die Einheit befindet sich im Schleichen-Modus</German>
             <Italian>Attiva o disattiva la capacità del gruppo IA di utilizzare autonomamente i bagliori per l'illuminazione di notte, a meno che non siano disponibili NVG o che l'unità sia in modalità invisibile</Italian>
             <Chinesesimp>切换AI组在夜间自主使用照明弹进行照明的功能除非NVG可用或单位处于隐身模式</Chinesesimp>
+        </Key>
+        <Key ID="STR_Lambs_Danger_Settings_DisableIncapacitatedKills">
+            <English>Disable units killing incapacitated enemies (ACE3)</English>
+        </Key>
+        <Key ID="STR_Lambs_Danger_Settings_DisableIncapacitatedKills_ToolTip">
+            <English>Disables AI groups ability to identify incapacitated enemies as threats in CQB (ACE3 only). Note that disabling this feature will add more instances where the AI gets stuck in CQB</English>
         </Key>
         <Key ID="STR_Lambs_Danger_Settings_CQBRange">
             <English>CQB Range</English>


### PR DESCRIPTION
**Potentially a controversial fix, but nonetheless grimly effective.** 

By allowing the AI to find and target ACE3 incapacitated enemies in CQB we FIX an inherent problem with the ACE3 system.  

Even though the incapacitated unit is rendered invisible, the FSM on an engine level still "knows" there is something there. But because the unit is invisible, it will merely start faffing about.  By allowing the AI to simply move there and kill the downed soldier, the problem resolves itself-- and the enemy becomes all the more deadly in CQB. 

Being incapacitated outside of CQB range is unchanged (and players and AI will still survive).