### PR TITLE
Remove Man class usage from range addon

### DIFF
--- a/addons/range/CfgVehicles.hpp
+++ b/addons/range/CfgVehicles.hpp
@@ -1,16 +1,6 @@
 class CfgVehicles {
-    class CAManBase;
-    class Civilian;
-    class SoldierWB: CAManBase {
-        sensitivity = 6;
-    };
-    class SoldierEB: CAManBase {
-        sensitivity = 6;
-    };
-    class SoldierGB: CAManBase {
-        sensitivity = 6;
-    };
-    class Civilian_F: Civilian {
+    class Man;
+    class CAManBase: Man {
         sensitivity = 6;
     };
 };

--- a/addons/range/CfgVehicles.hpp
+++ b/addons/range/CfgVehicles.hpp
@@ -1,6 +1,12 @@
 class CfgVehicles {
-    class Land;
-    class Man : Land {
+    class CAManBase;
+    class SoldierWB: CAManBase {
+        sensitivity = 6;
+    };
+    class SoldierEB: CAManBase {
+        sensitivity = 6;
+    };
+    class SoldierGB: CAManBase {
         sensitivity = 6;
     };
 };

--- a/addons/range/CfgVehicles.hpp
+++ b/addons/range/CfgVehicles.hpp
@@ -1,5 +1,6 @@
 class CfgVehicles {
     class CAManBase;
+    class Civilian;
     class SoldierWB: CAManBase {
         sensitivity = 6;
     };
@@ -7,6 +8,9 @@ class CfgVehicles {
         sensitivity = 6;
     };
     class SoldierGB: CAManBase {
+        sensitivity = 6;
+    };
+    class Civilian_F: Civilian {
         sensitivity = 6;
     };
 };


### PR DESCRIPTION
### When merged this pull request will: Title

1. *Describe what this pull request will do*
Replaces the *Man* class in the range addon with the classes modified by the danger addon for consistency. And also because *Man* applies to all animals too, which is probably not necessary.
2. *Each change in a separate line*
Replace *Man* class with the classes modified by the danger addon (*SoldierWB*, *SoldierEB*, *SoldierGB*)

Alternatively we can also modify *CAManBase*, but I think consistency with the application of fsmDanger is the best option.