### PR TITLE
Utilize throwables command

### DIFF
--- a/addons/main/functions/UnitAction/fnc_doSmoke.sqf
+++ b/addons/main/functions/UnitAction/fnc_doSmoke.sqf
@@ -30,23 +30,25 @@ if (_unit isEqualType grpNull) then {_unit = leader _unit;};
 // local
 if (!local _unit || {isPlayer _unit}) exitWith {false};
 
-// get magazines
-private _magazines = magazinesAmmo _unit;
-_magazines = _magazines select {(_x select 1) isEqualTo 1};
-_magazines = _magazines apply {_x select 0};
-if (_magazines isEqualTo []) exitWith {false};
+// get throwables
+private _throwables = throwables _unit;
+
+if (_throwables isEqualTo []) exitWith {false};
 
 // find smoke shell
-private _smokeshell = _magazines findIf {
-    [_x, _type] call FUNC(checkMagazineAiUsageFlags);
+private _smokeshellIndex = _throwables findIf {
+    [_x # 0, _type] call FUNC(checkMagazineAiUsageFlags);
 };
 
 // select smoke
-if (_smokeshell == -1) exitWith {false};
-_smokeshell = (_magazines select _smokeshell);
+if (_smokeshellIndex == -1) exitWith {false};
+private _smokeshell = ((_throwables # _smokeshellIndex) # 0);
+private _muzzle = ((_throwables # _smokeshellIndex) # 1);
 
-// get muzzle
-private _muzzle = _smokeshell call FUNC(getCompatibleThrowMuzzle);
+// the muzzle wasn't in the throwables array, use custom search
+if (_muzzle isEqualTo "") then {
+    _muzzle = _smokeshell call FUNC(getCompatibleThrowMuzzle);
+};
 
 // select muzzle
 if (_muzzle isEqualTo "") exitWith {false};


### PR DESCRIPTION
### When merged this pull request will:

1. *Describe what this pull request will do*

Use modern commands to make ``lambs_main_fnc_doSmoke`` slightly faster.

2. *Each change in a separate line*

- Use modern commands to make ``lambs_main_fnc_doSmoke`` slightly faster.

Performance increase comes from not having to find throwables from magazines and the potential of not having to call ``getCompatibleThrowMuzzle``. We still need to use it if we don't get a muzzle, because ``throwables`` does not return muzzles for all the throwables it finds (see: [biki example 1](https://community.bistudio.com/wiki/throwables)).

Requires Arma 3 version 2.18. Tested to work in singleplayer on the current 2.18 RC release.