### PR TITLE
Improvements to taskGarrison and taskCamp

### DIFF
--- a/addons/wp/XEH_preInit.sqf
+++ b/addons/wp/XEH_preInit.sqf
@@ -80,12 +80,10 @@ if (isServer) then {
 
 [QGVAR(taskCampReset), {
     params ["_unit"];
-    {
-        _x enableAI 'ANIM';
-        _x enableAI 'PATH';
-        [_x, _x getVariable [QGVAR(eventhandlers), []]] call EFUNC(main,removeEventhandlers);
-        _x setVariable [QGVAR(eventhandlers), nil];
-    } foreach (units _unit);
+    _unit enableAI 'ANIM';
+    _unit enableAI 'PATH';
+    [_unit, _unit getVariable [QGVAR(eventhandlers), []]] call EFUNC(main,removeEventhandlers);
+    _unit setVariable [QGVAR(eventhandlers), nil];
     [_unit, "", 2] call EFUNC(main,doAnimation);
     _unit setUnitPos "AUTO";
 }] call CBA_fnc_addEventhandler;

--- a/addons/wp/functions/fnc_taskCamp.sqf
+++ b/addons/wp/functions/fnc_taskCamp.sqf
@@ -117,7 +117,7 @@ reverse _units;
     if ((_buildings isNotEqualTo []) && { RND(0.6) }) then {
         _x setUnitPos "UP";
         private _buildingPos = selectRandom ((_buildings deleteAt 0) buildingPos -1);
-        if (_teleport) then { _x setPos _buildingPos; };
+        if (_teleport) then { _x setVehiclePosition [_buildingPos, [], 0, "CAN_COLLIDE"]; };
         _x doMove _buildingPos;
         [
             {
@@ -183,7 +183,7 @@ private _dir = random 360;
     // teleport
     if (_teleport) then {
         _x setDir (_x getDir _pos);
-        _x setPos _campPos;
+        _x setVehiclePosition [_campPos, [], 0, "CAN_COLLIDE"];
     };
 
     // execute move
@@ -232,7 +232,7 @@ _wp setWaypointStatements ["true", "
         {
             _x enableAI 'ANIM';
             _x enableAI 'PATH';
-            if (isNull objectParent _x) then {[_x, '', 2] call lambs_main_fnc_doAnimation;};
+            if (isNull objectParent _x && speed _x < 0.1) then {[_x, '', 2] call lambs_main_fnc_doAnimation;};
         } foreach thisList;
     };"
 ];


### PR DESCRIPTION
Adds garrisoned units that are placed outside will appear to look out from building
Improves garrison behaviour when there are no **indoor** locations (fixes issue #413)
Fixes units being teleported to building positions located in air
Fixes taskCamp units sometimes throwing double animation resets
Fixes taskCamp units failing to reset animations

--
Prefers using **setVehiclePosition** rather than **setPos** when placing units.  While more expensive, _taskGarrison_ and _taskCamp_ are not run frequently.  This neatly fixes many issues where units were spawned in the air (and fell to their deaths!) 

With the new and **improved eventhandlers** makes resetting animations in _taskCampReset_ is much more reliable. Therefore no need to run the function multiple times on all units. 