### PR TITLE
Improvements to brainEngage

### DIFF
--- a/addons/danger/functions/fnc_brainEngage.sqf
+++ b/addons/danger/functions/fnc_brainEngage.sqf
@@ -4,7 +4,7 @@
  * handles responses while engaging
  *
  * Arguments:
- * 0: unit doing the avaluation <OBJECT>
+ * 0: unit doing the evaluation <OBJECT>
  * 1: type of data <NUMBER>
  * 2: known target <OBJECT>
  *
@@ -32,10 +32,12 @@ private _timeout = time + 0.5;
 // check
 if (
     isNull _target
-    || {_unit knowsAbout _target isEqualTo 0}
+    || {(_unit knowsAbout _target) isEqualTo 0}
     || {(speed _target) > 20}
     || {(weapons _unit) isEqualTo []}
     || {(combatMode _unit) in ["BLUE", "GREEN"]}
+    || {(behaviour _unit) isEqualTo "STEALTH"}
+    || {(getUnitState _unit) in ["PLANNING", "BUSY"]}
 ) exitWith {
     _timeout + 1
 };
@@ -72,7 +74,7 @@ if (
         _posASL set [2, 0.5];
         _posASL = AGLToASL _posASL
     };
-    _unit forceSpeed 0;
+    _unit forceSpeed 1;
     _unit suppressFor 4;
     [_unit, _posASL vectorAdd [0, 0, 0.8], true] call EFUNC(main,doSuppress);
     _timeout + 4

--- a/addons/main/functions/UnitAction/fnc_doAssault.sqf
+++ b/addons/main/functions/UnitAction/fnc_doAssault.sqf
@@ -52,6 +52,11 @@ private _pos = call {
             getPosATL _unit
         };
 
+        // forget targets when too close
+        if (_unit distance2D _getHide < 1.7) then {
+            _unit forgetTarget _target;
+        };
+
         // select target location
         _doMove = true;
         _getHide
@@ -62,6 +67,7 @@ private _pos = call {
         private _group = group _unit;
         private _groupMemory = _group getVariable [QGVAR(groupMemory), []];
         if (_groupMemory isEqualTo []) then {
+            _buildings pushBack _getHide;
             _group setVariable [QGVAR(groupMemory), _buildings];
         };
     };

--- a/addons/main/functions/UnitAction/fnc_doAssaultMemory.sqf
+++ b/addons/main/functions/UnitAction/fnc_doAssaultMemory.sqf
@@ -18,7 +18,7 @@
 params ["_unit", ["_groupMemory", []]];
 
 // check if stopped
-if (!(_unit checkAIFeature "PATH")) exitWith {false};
+if (!(_unit checkAIFeature "PATH") || {(getUnitState _unit) isEqualTo "PLANNING"}) exitWith {false};
 
 // check it
 private _group = group _unit;
@@ -54,7 +54,7 @@ private _pos = _groupMemory select 0;
 private _distance2D = _unit distance2D _pos;
 
 // check for nearby enemy
-if (_unit distance2D _nearestEnemy < _distance2D) exitWith {
+if (_unit distance2D (_unit getHideFrom _nearestEnemy) < _distance2D) exitWith {
     [_unit, _nearestEnemy, 12, true] call FUNC(doAssault);
 };
 


### PR DESCRIPTION
Improve **brainEngage** by taking advantage of _getUnitState_
Improve **brainEngage** reimplements behaviour not triggering when **stealthed***
Fixes _doAssault_ where a unit would sometimes get stuck trying to check a position that the group believed the enemy is-- where it clearly could not be. (such as in the sky)**

*Not triggering _brainEngage_ when a unit is sneaking means that the AI become more predictable for player led groups, and unit set to ambush actually remain-ambushing.  Those set to sneak will not get mixed commands from their dangerAI

**It does this by simply forgetting the enemy, which is somewhat controversial but works very well in the context of group memory (i.e., if it is near a building, it will still have likely places to check). 

Makes me think we really should make our own _getHideFrom_ function.
