### PR TITLE
Improve Dodging and reactions

### DIFF
--- a/addons/danger/functions/fnc_brainReact.sqf
+++ b/addons/danger/functions/fnc_brainReact.sqf
@@ -35,11 +35,10 @@ _unit setVariable ["ace_medical_ai_lastHit", CBA_missionTime];
 
 // cover move when explosion
 if (
-    getSuppression _unit < 0.6
-    && {(speed _unit) isEqualTo 0}
-    && {_type in [DANGER_EXPLOSION, DANGER_FIRE]}
+    getSuppression _unit > 0.5
+    || {(getUnitState _unit) isEqualTo "REPLAN"}
+    || {(currentCommand _unit) isEqualTo "STOP"}
 ) exitWith {
-    _unit setUnitPosWeak "DOWN";
     [_unit] call EFUNC(main,doCover);
     _timeout + 1
 };

--- a/addons/main/functions/UnitAction/fnc_doCover.sqf
+++ b/addons/main/functions/UnitAction/fnc_doCover.sqf
@@ -19,8 +19,11 @@
 
 params ["_unit", ["_pos", [], [[]]]];
 
-// check if stopped
-if (!(_unit checkAIFeature "PATH")) exitWith {false};
+// stance change
+_unit setUnitPosWeak "DOWN";
+
+// check if stopped or inside a building
+if (!(_unit checkAIFeature "PATH") || {(insideBuilding _unit) isEqualTo 1}) exitWith {false};
 
 // find cover
 if (_pos isEqualTo []) then {

--- a/addons/main/functions/UnitAction/fnc_doCover.sqf
+++ b/addons/main/functions/UnitAction/fnc_doCover.sqf
@@ -15,7 +15,6 @@
  *
  * Public: No
 */
-#define SEARCH_FOR_HIDE 6
 
 params ["_unit", ["_pos", [], [[]]]];
 
@@ -27,7 +26,7 @@ if (!(_unit checkAIFeature "PATH") || {(insideBuilding _unit) isEqualTo 1}) exit
 
 // find cover
 if (_pos isEqualTo []) then {
-    _pos = nearestTerrainObjects [_unit, ["BUSH", "TREE", "HIDE"], SEARCH_FOR_HIDE, true, true];
+    _pos = nearestTerrainObjects [_unit, ["BUSH", "TREE", "HIDE"], 6, true, true];
     _pos = if (_pos isEqualTo []) then {
         getPosASL _unit
     } else {

--- a/addons/main/functions/UnitAction/fnc_doDodge.sqf
+++ b/addons/main/functions/UnitAction/fnc_doDodge.sqf
@@ -58,7 +58,8 @@ private _anim = call {
 
     // drop down
     if !(_nearDistance || {_still}) exitWith {
-        ["Down"]
+        _unit setUnitPosWeak "DOWN";
+        "Down"
     };
 
     // move back ~ more checks because sometimes we want the AI to move forward in CQB - nkenny


### PR DESCRIPTION
Take advantage of new _getUnitState_ command

Fix some cases of units warping through cover
Improve Dodge and Cover conditions. Units are more likely to drop prone and appear suppressed if under heavy fire.