### PR TITLE
Update fnc_debugDraw.sqf

### DIFF
--- a/addons/main/functions/debug/fnc_debugDraw.sqf
+++ b/addons/main/functions/debug/fnc_debugDraw.sqf
@@ -125,17 +125,19 @@ private _posCam = positionCameraToWorld [0, 0, 0];
 {
     private _unit = _x;
     private _renderPos = getPosATLVisual _unit;
+    private _isLeader = _unit isEqualTo (leader _unit);
+    private _sideColor = [side _unit, false] call BIS_fnc_sideColor;
     if ((_posCam distance _renderPos) <= _viewDistance) then {
         if (!GVAR(debug_drawAllUnitsInVehicles) && {_unit isNotEqualTo (effectiveCommander (vehicle _unit))}) exitWith {};
         private _textData =  ["<t align='bottom' size='%1'>"];
 
-        if (_unit == leader _unit) then {
+        if (_isLeader) then {
             {
                 private _pos2 = getPosATLVisual _x;
-                drawLine3D [_renderPos, _pos2, [1, 1, 1, 0.5]];
-            } forEach (units _unit);
+                drawLine3D [_renderPos, _pos2, [1, 1, 1, 0.5], 10];
+            } forEach ((units _unit) select {alive _x});
             private _color = GVAR(debug_sideColorLUT) getOrDefault [(side _unit), _sideUnknownColor]; // TODO: replace with new Syntax for setting default for hashMap!
-            _textData pushBack "<t size='%2' color='" + _color + "'>Group Leader</t><br/>";
+            _textData pushBack "<t shadow='0' size='%2' color='" + _color + "'>" + groupId (group _unit) + "</t><br/>";
         };
         _unit getVariable [QGVAR(FSMDangerCauseData), [-1, [0, 0, 0], -1]] params [["_dangerType", -1], ["_pos", [0, 0, 0]], ["_time", -1], ["_currentTarget", objNull]];
 
@@ -146,56 +148,76 @@ private _posCam = positionCameraToWorld [0, 0, 0];
                 private _knowledge = _unit targetKnowledge _currentTarget;
                 private _knowledgePosition = ASLToAGL(_knowledge select 6);
                 private _knowledgeAge = _knowledge select 2;
-                if (_knowledgeAge == time && _unitIsLocal) then {
+                if (_knowledgeAge isEqualTo time && _unitIsLocal) then {
                     _unit setVariable [QGVAR(debug_LastSeenPos), _knowledgePosition, GVAR(debug_functions)];
                 };
                 private _lastSeen = _unit getVariable [QGVAR(debug_LastSeenPos), _knowledgePosition];
+
+                // fix when particularly engaging suppressTargets
+                if (_knowledgePosition distanceSqr [0, 0, 0] < 1) then {
+                    _knowledgePosition = getPosATL _currentTarget;
+                    _lastSeen = getPosATL _currentTarget;
+                };
                 _targetKnowledge append [
                     "<t color='#C7CCC1'>Target Knowledge: <br/>",
                     "    Last Seen: ", _lastSeen, " (", _knowledgeAge toFixed 2, ")<br/>",
                     "    Position Error: ", (_knowledge select 5) toFixed 2, "</t><br/>"
                 ];
 
-                drawLine3D [_renderPos, _knowledgePosition, [0, 1, 0, 0.5]];
-                drawIcon3D ["a3\ui_f\data\Map\Markers\System\dummy_ca.paa", [1, 1, 1, 1], _knowledgePosition, 1, 1, 0, "Estimated Target Position"];
+                if (alive _currentTarget && {(side _unit) isNotEqualTo (side _currentTarget)}) then {
+                    drawLine3D [_renderPos, _knowledgePosition, _sideColor];
+                    drawIcon3D ["\a3\ui_f\data\igui\cfg\targeting\impactpoint_ca.paa", _sideColor, _knowledgePosition, 1, 1, 0, ["Estimated Target Position", ""] select (_knowledgePosition distanceSqr _lastSeen < 1)];
 
-                if !(_lastSeen isEqualType "") then {
-                    drawLine3D [_renderPos, _lastSeen, [0, 0, 1, 0.5]];
-                    drawIcon3D ["a3\ui_f\data\Map\Markers\System\dummy_ca.paa", [1, 1, 1, 1], _lastSeen, 1, 1, 0, "Last Seen Position"];
+                    if !(_lastSeen isEqualType "") then {
+                        drawLine3D [_knowledgePosition, _lastSeen, _sideColor];
+                        drawIcon3D ["\a3\ui_f\data\igui\cfg\targeting\hitprediction_ca.paa", _sideColor, _lastSeen, 1, 1, 0, ["Last Seen Position", ""] select (_knowledgePosition distanceSqr _lastSeen < 1)];
+                    };
                 };
+
             } else {
                 _targetKnowledge pushBack [
                     "<t color'#FFAA00'>RemoteSensors Disabled<br/>",
                     "<t color'#FFAA00'>and Unit Not Local<br/>"
                 ];
             };
-            drawLine3D [_renderPos, getPosATLVisual _currentTarget, [1, 0, 0, 1]];
+            //drawLine3D [_renderPos, getPosATLVisual _currentTarget, [1, 0, 0, 1]];  hide direct target lines to reduce clutter ~ nkenny
             [name _currentTarget, "None"] select (isNull _currentTarget);
         } else {
             if (_currentTarget isEqualType []) then {
-                drawLine3D [_renderPos, _currentTarget call CBA_fnc_getPos, [1, 0, 0, 1]];
+                drawLine3D [_renderPos, _currentTarget call CBA_fnc_getPos, _sideColor, 6];
+                drawIcon3D ["\a3\ui_f\data\igui\cfg\targeting\impactpoint_ca.paa", _sideColor, _currentTarget call CBA_fnc_getPos, 1, 1, 0];
                 format ["POS %1", _currentTarget];
             } else {
                 format ["N/A"];
-            }
+            };
         };
         _textData append [
             "Behaviour: ", behaviour _unit, "<br/>",
             "    Current Task: ", _unit getVariable [QGVAR(currentTask), "None"], "<br/>"
         ];
-        if (_unit == leader _unit) then {
+        if (_isLeader) then {
             private _targetCount = count ((_unit targetsQuery [objNull, sideUnknown, "", [], 0]) select {((side _unit) isNotEqualTo (side (_x select 1))) || ((side (_x select 1)) isEqualTo civilian)});
             _textData append [
                 "    Current Tactic: ", group _unit getVariable [QGVAR(currentTactic), "None"], "<br/>",
                 "    Known Enemies: ", _targetCount, "<br/>",
                 "    Group Memory: ", count (group _unit getVariable [QGVAR(groupMemory), []]), "<br/>"
             ];
+
+            {
+                drawIcon3D [
+                    "\a3\ui_f\data\igui\cfg\simpletasks\types\move_ca.paa",
+                    _sideColor,
+                    _x,
+                    0.7,
+                    0.7,
+                    0,
+                    str (_forEachIndex + 1)
+                ];
+            } forEach (group _unit getVariable [QGVAR(groupMemory), []]);
         };
-        private _currentCommand = currentCommand _unit;
-        if (_currentCommand == "") then {_currentCommand = "None";};
+
 
         _textData append [
-            "Current Command: ", _currentCommand, "<br/>",
             "<t color='#C7CCC1'>Danger Cause: ", _dangerType call FUNC(debugDangerType), "<br/>"
         ];
 
@@ -210,11 +232,16 @@ private _posCam = positionCameraToWorld [0, 0, 0];
             "Current Target: ", format ["%1 (%2 visiblity)", _name, ([objNull, "VIEW", objNull] checkVisibility [eyePos _unit, _currentTarget call _fnc_getEyePos]) toFixed 1], "<br/>"
         ];
 
-        _textData append _targetKnowledge;
+        //_textData append _targetKnowledge;    ~ Hidden to reduce information overload ~ nkenny
+
+        private _currentCommand = currentCommand _unit;
+        if (_currentCommand == "") then {_currentCommand = "None";};
 
         _textData append [
             "Supression: ", getSuppression _unit, "<br/>",
-            "Morale: ", morale _unit, "<br/>"
+            "Morale: ", morale _unit, "<br/>",
+            "Current Command: ", _currentCommand, "<br/>",
+            "UnitState: ", getUnitState _unit, "<br/>"
         ];
         if !(_unit checkAIFeature "PATH") then {
             _textData append ["<t color='#FFAA00'>PATH disabled</t>", "<br/>"];
@@ -239,8 +266,17 @@ private _posCam = positionCameraToWorld [0, 0, 0];
         if (GVAR(debug_RenderExpectedDestination)) then {
             (expectedDestination _unit) params ["_pos", "_planingMode", "_forceReplan"];
             if (_unit distance _pos > _viewDistance) exitWith {};
-            drawLine3D [_renderPos, _pos, [0, 0, 1, 0.5]];
-            drawIcon3D ["a3\ui_f\data\Map\Markers\System\dummy_ca.paa", [1, 1, 1, 1], _pos, 1, 1, 0, format ["%1m: %2%3", floor (_unit distance _pos), _planingMode, ["", " (ForceReplan)"] select _forceReplan]];
+            drawLine3D [_renderPos, _pos, [1, 1, 1, 1]];
+            private _iconSize = linearConversion [0, 30, speed _unit, 0.4, 1.2, true];
+            drawIcon3D [
+                "\a3\ui_f\data\igui\cfg\simpletasks\types\walk_ca.paa",
+                [1, 1, 1, 1],
+                _pos,
+                _iconSize,
+                _iconSize,
+                0,
+                format ["%1m: %2%3", floor (_unit distance _pos), _planingMode, ["", " (ForceReplan)"] select _forceReplan]
+            ];
         };
     };
 } forEach (allUnits select {!(isPlayer _x)});

--- a/addons/main/functions/debug/fnc_debugDraw.sqf
+++ b/addons/main/functions/debug/fnc_debugDraw.sqf
@@ -165,7 +165,7 @@ private _posCam = positionCameraToWorld [0, 0, 0];
                 ];
 
                 if ((side _unit) isNotEqualTo (side _currentTarget)) then {
-                    drawLine3D [ASLtoATL (aimPos _unit), _knowledgePosition, _sideColor, 6 * (1 - needReload _unit)];
+                    drawLine3D [ASLToATL (aimPos _unit), _knowledgePosition, _sideColor, 6 * (1 - needReload _unit)];
                     drawIcon3D ["\a3\ui_f\data\igui\cfg\targeting\impactpoint_ca.paa", _sideColor, _knowledgePosition, 1, 1, 0, ["Estimated Target Position", ""] select (_knowledgePosition distanceSqr _lastSeen < 1)];
 
                     if !(_lastSeen isEqualType "") then {


### PR DESCRIPTION
**Enhancements to debug draw banner readability.**

Added more icons
Added show _groupMemory_ positions
Added show _getUnitState_
Added colours to many 3D lines
Added thicker lines to indicate group membership
Removed target knowledge to hide clutter/excess information
Fixed issue when unit is suppressing (has no target knowledge)