### PR TITLE
Vehicle brain improvements

### DIFF
--- a/addons/danger/functions/fnc_brainVehicle.sqf
+++ b/addons/danger/functions/fnc_brainVehicle.sqf
@@ -4,7 +4,7 @@
  * handles vehicle brain
  *
  * Arguments:
- * 0: unit doing the avaluation <OBJECT>
+ * 0: unit doing the evaluation <OBJECT>
  * 2: current action queue <ARRAY>
  *
  * Return Value:
@@ -55,7 +55,7 @@ private _attack = _cause in [DANGER_ENEMYDETECTED, DANGER_ENEMYNEAR, DANGER_HIT,
 
 // update dangerPos if attacking. Check that the position is not too far above, or below ground.
 if (_attack) then {
-    private _dangerPos = _unit getHideFrom _dangerCausedBy;
+    _dangerPos = _unit getHideFrom _dangerCausedBy;
     if (_dangerPos isEqualTo [0, 0, 0]) exitWith {_attack = false;};
     _dangerPos = ASLToAGL (ATLToASL _dangerPos);
     if ((_dangerPos select 2) > 6 || {(_dangerPos select 2) < 2}) then {_dangerPos set [2, 1]};
@@ -78,6 +78,63 @@ if (_artillery) exitWith {
         {
             _x setSuppression 0.94; // to prevent instant laser aim on exiting vehicle
         } forEach _vehicleCrew; // There may be more than one unit in vehicle
+        [_unit, "Combat", "Eject", 125] call EFUNC(main,doCallout);
+    };
+
+    // mortars fire rounds
+    private _mortarTime = _vehicle getVariable [QEGVAR(main,mortarTime), 0];
+    if (_attack && {_vehicle isKindOf "StaticMortar"} && {unitReady _vehicle} && {_mortarTime < time}) then {
+
+        // delay
+        _timeout = _timeout + 2;
+        _vehicle doWatch _dangerPos;
+
+        // check ammo & range
+        private _ammo = getArtilleryAmmo [_vehicle];
+        private _shell = _ammo param [0, ""];
+        if (_shell isEqualTo "") exitWith {};
+        private _flareIndex = _ammo findIf {"flare" in (toLower _x)};
+        private _smokeIndex = _ammo findIf {"smoke" in (toLower _x)};
+
+        // check friendlies
+        private _dangerRound = false;
+        private _repeatRounds = true;
+        if ( RND(0.8) || { ([_unit, _dangerPos, 150] call EFUNC(main,findNearbyFriendlies)) isNotEqualTo [] } ) then {
+             if (_smokeIndex isNotEqualTo -1) then {
+                _shell = _ammo select _smokeIndex;
+                _repeatRounds = RND(0.5);
+             } else {
+                _dangerRound = true;
+             };
+        };
+
+        // check night
+        if ( RND(0.2) && { _unit call EFUNC(main,isNight) } && { _flareIndex isNotEqualTo -1 } ) then {
+            _dangerPos = _dangerPos getPos [-50 + random 100, (_vehicle getDir _dangerPos) - 45 + random 90];
+            _shell = _ammo select _flareIndex;
+            _dangerRound = false;
+            _repeatRounds = false;
+        };
+
+        // check for issues
+        if ( _dangerRound || !( _dangerPos inRangeOfArtillery [[_vehicle], _shell] ) ) exitWith {};
+
+        // execute fire command
+        _vehicle commandArtilleryFire [_dangerPos getPos [30 + random 80, (_dangerPos getDir _vehicle) - 10 + random 20], _shell, 1 + random 2];
+        _vehicle setVariable [QEGVAR(main,mortarTime), time + 24 + random 6];
+        _unit setVariable [QEGVAR(main,currentTask), "Mortar Fire", EGVAR(main,debug_functions)];
+        if (_repeatRounds) then {
+            [
+                {
+                    params [["_vehicle", objNull], ["_dangerPos", [0, 0, 0]], ["_shell", ""]];
+                    if (canFire _vehicle && unitReady _vehicle) then {
+                        _vehicle commandArtilleryFire [_dangerPos, _shell, ( 2 + random 1 ) min ((gunner _vehicle) ammo (currentMuzzle (gunner _vehicle)))];
+                    };
+                },
+                [_vehicle, _dangerPos, _shell],
+                18 + random 6
+            ] call CBA_fnc_waitAndExecute;
+        };
     };
     [_timeout] + _causeArray
 };
@@ -97,6 +154,7 @@ if (_vehicle isKindOf "StaticWeapon") exitWith {
     if ((count (magazines _vehicle)) isEqualTo 0 || {(_unit findNearestEnemy _dangerPos) distance _vehicle < (6 + random 15)}) then {
         private _vehicleCrew = (crew _vehicle);
         _vehicleCrew orderGetIn false;
+        [_unit, "Combat", "Eject"] call EFUNC(main,doCallout);
         {
             _x setSuppression 0.94; // to prevent instant laser aim on exiting vehicle
         } forEach _vehicleCrew; // There may be more than one unit in vehicle
@@ -113,7 +171,7 @@ if (_vehicle isKindOf "StaticWeapon") exitWith {
 };
 
 // update information
-if (_cause isEqualTo DANGER_ENEMYNEAR) then {[_unit, _dangerCausedBy] call EFUNC(main,doShareInformation);};
+if (_cause in [DANGER_ENEMYNEAR, DANGER_SCREAM]) then {[_unit, _dangerCausedBy] call EFUNC(main,doShareInformation);};
 
 // select turret ammunition
 if (_attack && {!EGVAR(main,disableAutonomousMunitionSwitching) && {!(isNull _dangerCausedBy) && {
@@ -143,14 +201,6 @@ if (_armored && {!isNull _dangerCausedBy}) exitWith {
     // keep cargo aboard!
     _vehicle setUnloadInCombat [false, false];
 
-    // vehicle jink
-    private _oldDamage = _vehicle getVariable [QGVAR(vehicleDamage), 0];
-    if (_validTarget && {_distance < (12 + random 15) || {damage _vehicle > _oldDamage}}) exitWith {
-        _vehicle setVariable [QGVAR(vehicleDamage), damage _vehicle];
-        [_unit] call EFUNC(main,doVehicleJink);
-        [_timeout + _delay] + _causeArray
-    };
-
     // foot infantry support ~ unload
     private _group = group _vehicle;
     private _cargo =  ((fullCrew [_vehicle, "cargo"]) apply {_x select 0});
@@ -179,7 +229,8 @@ if (_armored && {!isNull _dangerCausedBy}) exitWith {
         [
             {
                 params [["_cargo", []], ["_side", east], ["_vehicle", objNull]];
-                _cargo orderGetIn false;
+                {_x action ["Eject", _vehicle];} forEach _cargo;
+                [selectRandom _cargo, "Combat", "Dismount"] call EFUNC(main,doCallout);
                 _cargo allowGetIn false;
                 if (EGVAR(main,debug_functions)) then {["%1 %2 unloading %3 carried troops", _side, getText (configOf _vehicle >> "displayName"), count _cargo] call EFUNC(main,debugLog);};
             },
@@ -191,20 +242,40 @@ if (_armored && {!isNull _dangerCausedBy}) exitWith {
         [_timeout + _delay + 1] + _causeArray
     };
 
+    // move into gunners seat ~ Enemy Detected, commander alive but gunner dead
+    private _slow = speed _vehicle < 20;
+    if (
+        RND(0.4)
+        && {_slow}
+        && {someAmmo _vehicle}
+        && {_cause isEqualTo DANGER_ENEMYDETECTED}
+        && {!alive (gunner _vehicle)}
+        && {(commander _vehicle) call EFUNC(main,isAlive)}
+    ) exitWith {
+        (commander _vehicle) assignAsGunner _vehicle;
+        [_timeout + 3] + _causeArray
+    };
+
+    // vehicle jink
+    private _oldDamage = _vehicle getVariable [QGVAR(vehicleDamage), 0];
+    if (_slow && _validTarget && {_distance < (12 + random 15) || {damage _vehicle > _oldDamage}} && {(driver _vehicle) call EFUNC(main,isAlive)}) exitWith {
+        _vehicle setVariable [QGVAR(vehicleDamage), damage _vehicle];
+        [_unit] call EFUNC(main,doVehicleJink);
+        [_timeout + _delay] + _causeArray
+    };
+
     // tank assault
-    if (_attack && {speed _vehicle < 20}) then {
+    if (_attack && {_slow} && {(getUnitState _unit) isEqualTo "OK"}) then {
 
         // rotate
-        if ((getUnitState _unit) isEqualTo "OK") then {
-            [_vehicle, _dangerPos] call EFUNC(main,doVehicleRotate);
-        };
+        private _rotate = [_vehicle, _dangerPos] call EFUNC(main,doVehicleRotate);
 
         // assault
-        if (_distance < 750 && {_dangerCausedBy isKindOf "Man"} && {_cause isEqualTo DANGER_ENEMYDETECTED}) then {
+        if (!_rotate && {_distance < 750} && {_dangerCausedBy isKindOf "CAManBase"} && {(gunner _vehicle) call EFUNC(main,isAlive)}) then {
             [
                 {_this call EFUNC(main,doVehicleAssault)},
                 [_unit, _dangerPos, _dangerCausedBy],
-                _delay - 1
+                _delay - 1.5
             ] call CBA_fnc_waitAndExecute;
         };
     };
@@ -221,14 +292,47 @@ if (_car) exitWith {
     private _delay = 0;
     private _slow = speed _vehicle < 30;
 
+    // move into gunners seat ~ 30-90 meters and Enemy Detected
+    if (
+        _slow
+        && {canUnloadInCombat _vehicle}
+        && {someAmmo _vehicle}
+        && {_cause isEqualTo DANGER_ENEMYDETECTED}
+        && {_vehicle distanceSqr _dangerPos < (900 + random 3600)}
+        && {!alive (gunner _vehicle)}
+    ) exitWith {
+        _unit action ["Eject", _vehicle];
+        _unit assignAsGunner _vehicle;
+        [
+            {
+                params ["_unit", "_vehicle"];
+                if (_unit call EFUNC(main,isAlive)) then {
+                    [_unit, "Stealth", "Eject"] call EFUNC(main,doCallout);
+                    _unit setDir (_unit getDir _vehicle);
+                    _unit action ["getInGunner", _vehicle];
+                };
+            }, [_unit, _vehicle], 0.9
+        ] call CBA_fnc_waitAndExecute;
+        [_timeout + 3] + _causeArray
+    };
+
     // escape ~ if enemy within 15-50 meters or explosions are nearby!
-    if (_slow && {(side _dangerCausedBy) isNotEqualTo (side _unit)} && {_cause isEqualTo DANGER_EXPLOSION || {_vehicle distanceSqr _dangerCausedBy < (225 + random 1225)}}) exitWith {
+    if (
+        _slow
+        && {(side _dangerCausedBy) isNotEqualTo (side _unit)}
+        && {_cause isEqualTo DANGER_EXPLOSION || {_vehicle distanceSqr _dangerCausedBy < (225 + random 1225)}}
+        && {(driver _vehicle) call EFUNC(main,isAlive)}
+    ) exitWith {
         [_unit] call EFUNC(main,doVehicleJink);
         [_timeout + 3] + _causeArray
     };
 
-    // look to danger
-    if (_attack && {_vehicle knowsAbout _dangerCausedBy > 3}) then {_vehicle doWatch (AGLToASL _dangerPos);};
+    // look toward danger
+    if (
+        _attack
+        && {_vehicle knowsAbout _dangerCausedBy > 3}
+        && {(gunner _vehicle) call EFUNC(main,isAlive)}
+    ) then {_vehicle doWatch (AGLToASL _dangerPos);};
 
     // suppression
     if (_attack && {_slow}) then {
@@ -239,6 +343,27 @@ if (_car) exitWith {
 
     // end
     [_timeout + _delay] + _causeArray
+};
+
+// vehicle type ~ Unarmed car
+if (_vehicle isKindOf "Car_F" && {!someAmmo _vehicle}) then {
+
+    // speed
+    private _stopped = speed _vehicle < 2;
+
+    // is static and a driver and enemy near and a threat - enemy within 10-35 meters
+    if (
+        _stopped
+        && {!isNull (driver _vehicle)}
+        && {canUnloadInCombat _vehicle}
+        && {_cause isEqualTo DANGER_ENEMYDETECTED}
+        && {_vehicle distanceSqr _dangerCausedBy < (100 + random 225)}
+    ) then {
+        private _driver = driver _vehicle;
+        _driver action ["Eject", _vehicle];
+        _driver setSuppression 0.94; // to prevent instant laser aim on exiting vehicle
+        [_driver, "Combat", "Eject"] call EFUNC(main,doCallout);
+    };
 };
 
 // Make leadership assessment as infantry

--- a/addons/main/functions/VehicleAction/fnc_doVehicleAssault.sqf
+++ b/addons/main/functions/VehicleAction/fnc_doVehicleAssault.sqf
@@ -66,7 +66,7 @@ _unit setVariable [QEGVAR(main,currentTarget), _target, EGVAR(main,debug_functio
 _unit setVariable [QEGVAR(main,currentTask), "Vehicle Assault", EGVAR(main,debug_functions)];
 
 // minor jink if no suppression possible
-if (!_suppression) then {[_unit, 25] call FUNC(doVehicleJink)};
+if (!_suppression) exitWith {[_unit, 35] call FUNC(doVehicleJink)};
 
 // cannon direction ~ threshold 30 degrees
 private _fnc_turretDir = {

--- a/addons/main/functions/VehicleAction/fnc_doVehicleJink.sqf
+++ b/addons/main/functions/VehicleAction/fnc_doVehicleJink.sqf
@@ -23,8 +23,8 @@ private _vehicle = vehicle _unit;
 // cannot move or moving
 if (
     !canMove _vehicle
-    || {currentCommand _vehicle isEqualTo "MOVE"
-    || currentCommand _vehicle isEqualTo "ATTACK"}
+    || { (fuel _vehicle) < 0.1 }
+    || { (currentCommand _vehicle) in ["MOVE", "ATTACK"] }
     ) exitWith {
     getPosASL _unit
 };

--- a/addons/main/functions/VehicleAction/fnc_doVehicleRotate.sqf
+++ b/addons/main/functions/VehicleAction/fnc_doVehicleRotate.sqf
@@ -10,7 +10,7 @@
  * Arguments:
  * 0: Vehicle rotating <OBJECT>
  * 1: Direction which to turn towards <ARRAY>
- * 2: Acceptible threshold in degrees <NUMBER>
+ * 2: Acceptable threshold in degrees <NUMBER>
  *
  * Return Value:
  * success
@@ -26,42 +26,52 @@ if (_target isEqualTo []) then {
     _target = _unit getHideFrom (_unit findNearestEnemy _unit);
 };
 if (_target isEqualTo [0, 0, 0] || {_unit distanceSqr _target < 2}) exitWith {false};
+_target = _target call CBA_fnc_getPos;
 
 // cannot move or moving
-if (!canMove _unit || {currentCommand _unit isEqualTo "MOVE"}) exitWith {false};
+private _vehicle = vehicle _unit;
+if (!canMove _vehicle || {(currentCommand _vehicle) isEqualTo "MOVE"} || {!alive (driver _vehicle)}) exitWith {false};
 
-// CQB tweak -- target within 75m - look instead
-if (_unit distanceSqr _target < 5625) exitWith {
-    (vehicle _unit) doWatch (ATLToASL _target);
+// CQB tweak -- target within 35m - look instead
+if (_unit distanceSqr _target < 1225) exitWith {
+    _vehicle doWatch (ATLToASL _target);
     false
 };
 
 _unit setVariable [QGVAR(currentTarget), _target, GVAR(debug_functions)];
 _unit setVariable [QGVAR(currentTask), "Vehicle Rotate", GVAR(debug_functions)];
 
-// within acceptble limits
+// within acceptable limits
 if (_unit getRelDir _target < _threshold || {_unit getRelDir _target > (360-_threshold)}) exitWith {
     false
 };
 
-// settings
-private _pos = [];
-private _min = 20;      // Minimum range
-
-for "_i" from 0 to 5 do {
-    _pos = (_unit getPos [_min, _unit getDir _target]) findEmptyPosition [0, 2.2, typeOf _unit];
-
-    // water or exit
-    if !(_pos isEqualTo [] || {surfaceIsWater _pos}) exitWith {};
-
-    // update
-    _min = _min + 15;
-};
-if (_pos isEqualTo []) then {_pos = _unit modelToWorldVisual [0, -100, 0]};
-
 // move
-_unit doMove _pos;
-_unit setFormDir (_unit getDir _pos);
+_unit setFormDir (_unit getDir _target);
+if (_vehicle isKindOf "Tank") then {
+
+    // turn vehicle
+    _vehicle sendSimpleCommand (["LEFT", "RIGHT"] select (_unit getRelDir _target < 180));
+
+} else {
+
+    // settings
+    private _pos = [];
+    private _min = 20;      // Minimum range
+
+    for "_i" from 0 to 5 do {
+        _pos = (_unit getPos [_min, _unit getDir _target]) findEmptyPosition [0, 2.2, typeOf _unit];
+
+        // water or exit
+        if !(_pos isEqualTo [] || {surfaceIsWater _pos}) exitWith {};
+
+        // update
+        _min = _min + 15;
+    };
+    if (_pos isEqualTo []) then {_pos = _unit modelToWorldVisual [0, -100, 0]};
+    _unit doMove _pos;
+};
+
 
 // waitUntil
 [
@@ -74,12 +84,17 @@ _unit setFormDir (_unit getDir _pos);
         if (canMove _unit && {(crew _unit) isNotEqualTo []}) then {
 
             // refresh ready
-            (effectiveCommander _unit) doMove (getPosASL _unit);
+            (vehicle _unit) sendSimpleCommand "STOPTURNING";
+            (effectiveCommander _unit) doMove (_unit getPos [10, _unit getDir _target]);
 
             // refresh formation
             (group _unit) setFormDir (_unit getDir _target);
         };
-    }, [_unit, _target, _threshold], (4 + random 6)
+    }, [_unit, _target, _threshold * 2], 4 + random 3,
+    {
+        params ["_unit"];
+        (vehicle _unit) sendSimpleCommand "STOPTURNING";
+    }
 ] call CBA_fnc_waitUntilAndExecute;
 
 // end

--- a/addons/main/functions/VehicleAction/fnc_doVehicleSuppress.sqf
+++ b/addons/main/functions/VehicleAction/fnc_doVehicleSuppress.sqf
@@ -18,13 +18,13 @@
 params ["_unit", ["_pos", [0, 0, 0]]];
 
 private _vehicle = vehicle _unit;
-_pos = _pos call CBA_fnc_getPos;
+private _pos = _pos call CBA_fnc_getPos;
 
 // exit if vehicle is moving too fast or target is too high
-if (speed _vehicle > 30 || {(_pos select 2) > 100}) exitWith {false};
+if (speed _vehicle > 30 || {(_pos select 2) > 100} || {!((gunner _vehicle) call FUNC(isAlive))}) exitWith {false};
 
 // pos
-private _eyePos = eyePos _unit;
+private _eyePos = eyePos _vehicle;
 _pos = (AGLToASL _pos) vectorAdd [0.5 - random 1, 0.5 - random 1, 0.3 + random 1.3];
 
 // target is close or terrain occludes target
@@ -34,7 +34,7 @@ if (
 ) exitWith {false};
 
 // artillery (no tactical options)
-if (_vehicle getVariable [QGVAR(isArtillery), getNumber (configOf (vehicle _unit) >> "artilleryScanner") > 0]) exitWith {
+if (_vehicle getVariable [QGVAR(isArtillery), getNumber (configOf _vehicle >> "artilleryScanner") > 0]) exitWith {
     _vehicle setVariable [QGVAR(isArtillery), true];
     false
 };
@@ -44,7 +44,7 @@ _unit setVariable [QGVAR(currentTarget), _pos, GVAR(debug_functions)];
 _unit setVariable [QGVAR(currentTask), "Vehicle Suppress", GVAR(debug_functions)];
 
 // trace
-private _vis = lineIntersectsSurfaces [_eyePos, _pos, _unit, vehicle _unit, true, 1, "GEOM", "VIEW"];
+private _vis = lineIntersectsSurfaces [_eyePos, _pos, _unit, _vehicle, true, 1, "GEOM", "VIEW"];
 if (_vis isNotEqualTo []) then {_pos = (_vis select 0) select 0;};
 
 // recheck

--- a/addons/main/functions/debug/fnc_debugDraw.sqf
+++ b/addons/main/functions/debug/fnc_debugDraw.sqf
@@ -127,7 +127,7 @@ private _posCam = positionCameraToWorld [0, 0, 0];
     private _renderPos = getPosATLVisual _unit;
     private _isLeader = _unit isEqualTo (leader _unit);
     private _sideColor = [side (group _unit), false] call BIS_fnc_sideColor;
-    if ((_posCam distance _renderPos) <= _viewDistance && {((units _unit - [_unit]) findIf {_x distanceSqr _unit < 1}) isEqualTo -1}) then {
+    if ((_posCam distance _renderPos) <= _viewDistance) then {
         if (!GVAR(debug_drawAllUnitsInVehicles) && {_unit isNotEqualTo (effectiveCommander (vehicle _unit))}) exitWith {};
         private _textData =  ["<t align='bottom' size='%1'>"];
 

--- a/addons/main/functions/fnc_doCallout.sqf
+++ b/addons/main/functions/fnc_doCallout.sqf
@@ -59,6 +59,9 @@ switch (toLowerANSI(_callout)) do {
     case ("flank"): {
         _callout = selectRandom ["OnYourFeet", "Advance", "FlankLeft", "FlankRight"];
     };
+    case ("eject"): {
+        _callout = selectRandom ["Eject", "EndangeredE"];
+    };
 };
 
 private _cacheName = format ["%1_%2_%3_%4", QGVAR(callouts), _speaker, _behavior, _callout];
@@ -79,7 +82,7 @@ if (isNil "_cachedSounds") then {
             _cachedSounds set [_forEachIndex, objNull];
             continue;
         };
-        
+
         private _hasFileEnding = _sound regexMatch ".+?\.(?:ogg|wss|wav|mp3)$/io";
 
         if (_sound select [0, 1] != "\") then {


### PR DESCRIPTION
Many additions to vehicle brain centered around three common themes: 
- Improve vehicle combat and interractions
- Rearranging dead crew to improve vehicle command
- Allow mortars to do dynamic close support

-------------


Added mortars support nearby units with Smoke, Flares and HE
Added Tanks/APC/IFVs will rearrange crew to prioritise guns
Added ability for Tracked vehicles to rearrange crew (even when fleeing)
Added ability for crew to jump out of soft-skinned vehicles and man mounted weapons
Added ability for crew of soft-skinned vehicles to jump out to defend themselves
Added callouts/vocalization to many vehicle interactions
Added more chances for vehicles to share information

Improved APC/IFV vehicle dismounts more reliable
Improved vehicle rotate on tracked vehicles with '_sendSimpleCommand_'
Improved hiding ability of fleeing infantry
Improved readability of vehicle code

Fixed cases where incapacitated gunners still turned turrets
Fixed **_stupid_** bug where _dangerPos_ was not properly updated in brainVehicle.sqf
Fixed bug where banners were often hidden on some vehicles in debugDraw