### PR TITLE
Mortar and Static weapons improvements

### DIFF
--- a/addons/danger/functions/fnc_tacticsAssess.sqf
+++ b/addons/danger/functions/fnc_tacticsAssess.sqf
@@ -211,9 +211,10 @@ if (!(GVAR(disableAutonomousFlares)) && {_unit call EFUNC(main,isNight)}) then {
     _units = [_units] call EFUNC(main,doUGL);
 };
 
-// man empty static weapons
+// man empty static weapons and deploy static weapons
 if !(GVAR(disableAIFindStaticWeapons)) then {
     _units = [_units, _unit] call EFUNC(main,doGroupStaticFind);
+    _units = [_units, _pos] call EFUNC(main,doGroupStaticDeploy);
 };
 
 // no plan ~ exit with no executable plan
@@ -238,11 +239,6 @@ if (
 ) then {
     _unit selectWeapon (binocular _unit);
     _unit doWatch _pos;
-};
-
-// deploy static weapons
-if !(GVAR(disableAIDeployStaticWeapons)) then {
-    _units = [_units, _pos] call EFUNC(main,doGroupStaticDeploy);
 };
 
 // enact plan

--- a/addons/danger/functions/fnc_tacticsContact.sqf
+++ b/addons/danger/functions/fnc_tacticsContact.sqf
@@ -68,7 +68,7 @@ _group setFormDir (_unit getDir _enemy);
 
 // gesture + callouts for larger units
 private _stealth = (behaviour _unit) isEqualTo "STEALTH";
-private _units = (units _unit) select {(currentCommand _x) in ["", "MOVE"] && {!isPlayer _x} && {isNull objectParent _x} && {_x checkAIFeature "MOVE"} && {_x checkAIFeature "PATH"}};
+private _units = (units _unit) select {(currentCommand _x) in ["", "MOVE"] && {!isPlayer _x} && {isNull objectParent _x} && {_x checkAIFeature "MOVE"} && {_x checkAIFeature "PATH"} && {!(_x getVariable [QGVAR(forceMove), false])}};
 private _count = count _units;
 if (_count > 2) then {
     // gesture

--- a/addons/main/XEH_PREP.hpp
+++ b/addons/main/XEH_PREP.hpp
@@ -37,6 +37,8 @@ SUBPREP(GroupAction,doGroupSuppress);
 SUBPREP(GroupAction,doGroupStaticDeploy);
 SUBPREP(GroupAction,doGroupStaticFind);
 SUBPREP(GroupAction,doGroupStaticPack);
+SUBPREP(GroupAction,doGroupCommandoDeploy);
+SUBPREP(GroupAction,doGroupCommandoPack);
 
 SUBPREP(UnitAction,doAssault);
 SUBPREP(UnitAction,doAssaultCQB);

--- a/addons/main/functions/GroupAction/fnc_doGroupCommandoDeploy.sqf
+++ b/addons/main/functions/GroupAction/fnc_doGroupCommandoDeploy.sqf
@@ -1,0 +1,105 @@
+#include "script_component.hpp"
+/*
+ * Author: nkenny
+ * Deploy commando mortar introduced in Reaction Forced CDLC
+ *
+ * Arguments:
+ * 0: unit carrying mortar <OBJECT>
+ * 1: position to deploy weapon <ARRAY>
+ *
+ * Return Value:
+ * bool
+ *
+ * Example:
+ * [unit, getPos angryJoe] call lambs_main_fnc_doGroupCommandoDeploy;
+ *
+ * Public: No
+*/
+
+params ["_unit", ["_weaponPos", []]];
+
+// alive and update pos
+if !(_unit call EFUNC(main,isAlive)) exitWith {false};
+
+// add eventhandler
+private _EH = _unit addEventHandler ["WeaponAssembled", {
+    params ["_unit", "_weapon"];
+
+    // get in weapon
+    _unit assignAsGunner _weapon;
+    _unit moveInGunner _weapon;
+
+    // check artillery
+    if (GVAR(Loaded_WP) && {_weapon getVariable [QGVAR(isArtillery), getNumber (configOf _weapon >> "artilleryScanner") > 0]}) then {
+        [group _unit] call EFUNC(wp,taskArtilleryRegister);
+    };
+
+    // remove EH
+    _unit removeEventHandler ["WeaponAssembled", _thisEventHandler];
+}];
+
+// find position
+if (_weaponPos isEqualTo []) then {
+    private _unitPos = getPos _unit;
+    _weaponPos = [_unitPos, 0, 7, 3, 0, 0.07, 0, [], [_unitPos, _unitPos]] call BIS_fnc_findSafePos;
+    _weaponPos set [2, 0];
+};
+
+// ready unit
+doStop _unit;
+_unit doWatch _weaponPos;
+_unit setUnitPos "MIDDLE";
+_unit forceSpeed 24;
+_unit setVariable [QEGVAR(danger,forceMove), true];
+_unit setVariable [QGVAR(currentTask), "Deploy Commando Mortar", GVAR(debug_functions)];
+_unit setVariable [QGVAR(currentTarget), _weaponPos, GVAR(debug_functions)];
+_unit doMove _weaponPos;
+_unit setDestination [_weaponPos, "LEADER DIRECT", true];
+
+// do it
+[
+    {
+        // condition
+        params ["_gunner", "_weaponPos"];
+        (_gunner call FUNC(isAlive)) && { _gunner distance2D _weaponPos < 1.2 || { unitReady _gunner } }
+    },
+    {
+        // on near gunner
+        params ["_gunner"];
+
+        // assemble weapon
+        private _weaponHolder = createVehicle ["GroundWeaponHolder_Scripted", getPos _gunner, [], 0, "NONE"];
+        _gunner action ["Assemble", _weaponHolder];
+
+        // organise weapon and gunner
+        [
+            {
+                params ["_gunner"];
+                private _weapon = vehicle _gunner;
+                _weapon setVectorUp ( surfaceNormal ( getPos _weapon ) );
+
+                // register
+                private _group = group _gunner;
+                private _weaponList = _group getVariable [QGVAR(staticWeaponList), []];
+                _weaponList pushBackUnique _weapon;
+                _group setVariable [QGVAR(staticWeaponList), _weaponList, true];
+
+                // reset
+                _gunner setVariable [QEGVAR(danger,forceMove), nil];
+                _gunner setUnitPos "AUTO";
+            }, [_gunner], 1
+        ] call CBA_fnc_waitAndExecute;
+    },
+    [_unit, _weaponPos, _EH], 9,
+    {
+        // on timeout
+        params ["_gunner", "", "_EH"];
+        [_gunner] doFollow (leader _gunner);
+        _gunner setVariable [QEGVAR(danger,forceMove), nil];
+        _gunner setUnitPos "AUTO";
+        _gunner removeEventHandler ["WeaponAssembled", _EH];
+    }
+] call CBA_fnc_waitUntilAndExecute;
+
+// end
+true

--- a/addons/main/functions/GroupAction/fnc_doGroupCommandoPack.sqf
+++ b/addons/main/functions/GroupAction/fnc_doGroupCommandoPack.sqf
@@ -1,0 +1,48 @@
+#include "script_component.hpp"
+/*
+ * Author: nkenny
+ * Pack commando mortar introduced in Reaction Forced CDLC
+ *
+ * Arguments:
+ * 0: weapon to pack <OBJECT>
+ *
+ * Return Value:
+ * bool
+ *
+ * Example:
+ * [units bob, getPos angryJoe] call lambs_main_fnc_doGroupCommandoPack;
+ *
+ * Public: No
+*/
+
+params ["_gun"];
+
+private _gunner = gunner _gun;
+
+// callout
+[leader _gunner, "aware", "DisassembleThatWeapon"] call FUNC(doCallout);
+
+private _EH = _gunner addEventHandler ["WeaponDisassembled", {
+        params ["_gunner", "_weaponBag"];
+
+        // get bags
+        _gunner action ["TakeBag", _weaponBag];
+
+        // remove EH
+        _gunner removeEventHandler ["WeaponDisassembled", _thisEventHandler];
+    }
+];
+
+// get mortar
+private _vehicle = vehicle _gunner;
+
+// disassemble
+moveOut _gunner;
+(group _gunner) leaveVehicle (assignedVehicle _gunner);
+unassignVehicle _gunner;
+
+// do action
+_gunner action ["Disassemble", _vehicle];
+
+// end
+true

--- a/addons/main/functions/GroupAction/fnc_doGroupStaticPack.sqf
+++ b/addons/main/functions/GroupAction/fnc_doGroupStaticPack.sqf
@@ -36,6 +36,13 @@ if (_guns isEqualTo []) then {
 _guns = _guns select {alive _x && {(vehicle _x) isKindOf "StaticWeapon"} && ((crew _x) isNotEqualTo [])};
 if (_guns isEqualTo []) exitWith { _units };
 
+// check for commando mortars
+private _commandoIndex = _guns findIf {(vehicle _x) isKindOf "CommandoMortar_base_RF"};
+if (_commandoIndex isNotEqualTo -1) exitWith {
+    [_guns select _commandoIndex] call FUNC(doGroupCommandoPack);
+    _units
+};
+
 // get gunner
 private _weapon = _guns deleteAt 0;
 private _gunner = gunner _weapon;
@@ -75,7 +82,7 @@ private _EH = _gunner addEventHandler ["WeaponDisassembled", {
 // assistant moves to gunner
 doStop _assistant;
 _assistant doWatch vehicle _gunner;
-_assistant setUnitPosWeak "MIDDLE";
+_assistant setUnitPos "MIDDLE";
 _assistant forceSpeed 24;
 _assistant setVariable [QEGVAR(danger,forceMove), true];
 _assistant setVariable [QGVAR(currentTask), "Pack Static Weapon", GVAR(debug_functions)];
@@ -102,7 +109,7 @@ _assistant doMove getPosATL (vehicle _gunner);
         _group leaveVehicle assignedVehicle _gunner;
         unassignVehicle _gunner;
 
-        // dissassemble weapon
+        // disassemble weapon
         _gunner action ["Disassemble", _weapon];
 
         // de-register
@@ -113,6 +120,7 @@ _assistant doMove getPosATL (vehicle _gunner);
         // follow!
         [_gunner, _assistant] doFollow (leader _gunner);
         _assistant setVariable [QEGVAR(danger,forceMove), nil];
+        _assistant setUnitPos "AUTO";
     },
     [_gunner, _assistant, getPosATL _weapon, _EH], 10,
     {
@@ -122,6 +130,7 @@ _assistant doMove getPosATL (vehicle _gunner);
         // assistant reverts
         _assistant doFollow (leader _assistant);
         _assistant setVariable [QEGVAR(danger,forceMove), nil];
+        _assistant setUnitPos "AUTO";
 
         // removes eventhandler
         _gunner removeEventHandler ["WeaponDisassembled", _EH];


### PR DESCRIPTION
Adds ability to deploy commando mortars introduced in Reaction Forces CDLC
Adds increased likelihood of small teams deploying static weapons
Fixes issue where deploying troops could be distracted by contact states
Improves misc. aspects of deploying static weapons

While still subject to suppression and distraction by enemy forces. This pull request makes backpack static weapons much more likely to be deployed