### PR TITLE
Revisiting TacticsAssault, doGroupAssault, doAssault, doMemoryAssault

### DIFF
--- a/addons/danger/functions/fnc_tacticsAssault.sqf
+++ b/addons/danger/functions/fnc_tacticsAssault.sqf
@@ -18,7 +18,7 @@
  *
  * Public: No
 */
-params ["_group", "_target", ["_units", []], ["_cycle", 18], ["_delay", 85]];
+params ["_group", "_target", ["_units", []], ["_cycle", 18], ["_delay", 160]];
 
 // group is missing
 if (isNull _group) exitWith {false};

--- a/addons/main/functions/GroupAction/fnc_doGroupAssault.sqf
+++ b/addons/main/functions/GroupAction/fnc_doGroupAssault.sqf
@@ -34,7 +34,7 @@ if (_units isEqualTo [] || {_pos isEqualTo []}) exitWith {
 private _targetPos = _pos select 0;
 
 // reorder positions
-_pos = _pos apply {[_targetPos isEqualTo (round (_x select 2)), _targetPos distanceSqr _x, _x]};
+_pos = _pos apply {[(round (_targetPos select 2)) + (round (_x select 2)), _targetPos distanceSqr _x, _x]};
 _pos sort true;
 _pos = _pos apply {_x select 2};
 
@@ -44,18 +44,49 @@ _pos = _pos apply {_x select 2};
     private _assaultPos = _targetPos;
     if (((_forEachIndex % 4) isEqualTo 0) && {count _pos > 1}) then {_assaultPos = _pos select 1};
 
+    // enemy
+    private _enemy = _unit findNearestEnemy _unit;
+    if (alive _enemy) then {
+        private _vis = [objNull, "VIEW", objNull] checkVisibility [eyePos _unit, aimPos _enemy] > 0.9;
+
+        // can see enemy or enemy within 5 meters
+        if (_vis || {_unit distanceSqr _enemy < 25}) then {
+            _unit lookAt (ASLtoAGL (aimPos _enemy));
+            _assaultPos = getPosATL _enemy;
+        };
+    };
+
+    // unit situation
+    private _distance2D = _unit distance2D _assaultPos;
+    private _indoor = [_unit] call FUNC(isIndoor);
+
     // manoeuvre
-    _unit forceSpeed 3;
-    _unit setUnitPos (["UP", "MIDDLE"] select ((getSuppression _x) isNotEqualTo 0 || {_unit distance2D _assaultPos > 8}));
-    _unit setVariable [QGVAR(currentTask), format ["Group Assault @ %1m", round (_unit distance _assaultPos)], GVAR(debug_functions)];
+    _unit forceSpeed ([4, 2] select (_indoor || {_distance2D < 10}));
+    _unit setUnitPos (["UP", "MIDDLE"] select ((getSuppression _unit) isNotEqualTo 0 || {_distance2D > 8}));
+    _unit setVariable [QGVAR(currentTask), format ["Group Assault @ %1m", round _distance2D], GVAR(debug_functions)];
     _unit setVariable [QEGVAR(danger,forceMove), true];
 
+    // modify assaultPos
+    private _nearMen = _assaultPos nearEntities ["CAManBase", 1];
+    if (_nearMen isNotEqualTo []) then {
+        _enemy = _nearMen select 0;
+        private _surface = lineIntersectsSurfaces [(getPosASL _enemy) vectorAdd [0, 0, 2], (getPosASL _enemy) vectorAdd [-15 + random 30, -15 + random 30, -4], _enemy, objNull, true, 1, "GEOM", "VIEW"];
+        if (_surface isNotEqualTo []) then {
+            _assaultPos = (ASLtoAGL ((_surface select 0) select 0));
+        };
+    };
+
     // modify movement (if far)
-    if (_unit distanceSqr _assaultPos > 400 && {!([_unit] call FUNC(isIndoor))}) then {
+    if (_distance2D > 20 && {!_indoor}) then {
         _assaultPos = _unit getPos [20, _unit getDir _assaultPos];
     };
+
     // set movement
-    if (((expectedDestination _unit) select 0) distanceSqr _assaultPos > 1) then {
+    if (
+        ((expectedDestination _unit) select 0) distanceSqr _assaultPos > 1
+        && {!((getUnitState _unit) in ["BUSY", "DELAY"])}
+    ) then {
+        _unit lookAt (_assaultPos vectorAdd [0, 0, 1]);
         _unit doMove _assaultPos;
         _unit setDestination [_assaultPos, "LEADER PLANNED", true];
     };
@@ -63,21 +94,21 @@ _pos = _pos apply {_x select 2};
     // remove positions
     _pos = _pos select {[objNull, "VIEW", objNull] checkVisibility [eyePos _unit, (AGLToASL _x) vectorAdd [0, 0, 0.5]] < 0.01};
 
-} forEach (_units select {!((getUnitState _x) in ["PLANNING", "BUSY"])});
+} forEach _units;
 
 // update group variable
 (group (_units select 0)) setVariable [QGVAR(groupMemory), _pos, false];
 
-// remove  positions
-_pos = _pos select {(_units select 0) distance _x > 3};
-if (RND(0.95)) then {_pos deleteAt 0;};
+// remove  positions ~ uncommented. CheckVisibility should be sufficient. Worth testing first ~ nkenny
+// _pos = _pos select {(_units select 0) distance _x > 3};
+// if (RND(0.95)) then {_pos deleteAt 0;};
 
 // recursive cyclic
 if !(_cycle <= 1 || {_units isEqualTo []}) then {
     [
         {_this call FUNC(doGroupAssault)},
         [_cycle - 1, _units, _pos],
-        4
+        3
     ] call CBA_fnc_waitAndExecute;
 };
 

--- a/addons/main/functions/UnitAction/fnc_doAssault.sqf
+++ b/addons/main/functions/UnitAction/fnc_doAssault.sqf
@@ -34,7 +34,7 @@ private _pos = call {
 
     // can see target!
     if (_vis) exitWith {
-        _unit lookAt (aimPos _target);
+        _unit lookAt (ASLToAGL (aimPos _target));
         getPosATL _target
     };
 
@@ -49,6 +49,7 @@ private _pos = call {
         if (_unit call FUNC(isIndoor) && {RND(GVAR(indoorMove))}) exitWith {
             _unit setVariable [QGVAR(currentTask), "Stay inside", GVAR(debug_functions)];
             _unit setUnitPosWeak "MIDDLE";
+            _unit lookAt _getHide;
             getPosATL _unit
         };
 
@@ -89,10 +90,11 @@ if (_doMove) then {_unit doMove _pos;};
 // debug
 if (GVAR(debug_functions)) then {
     [
-        "%1 %2 %3(%4 @ %5m)",
+        "%1 %2 %3%4(%5 @ %6m)",
         side _unit,
         ["assaulting ", "staying inside "] select (_unit distance2D _pos < 1),
         ["(building) ", ""] select (_buildings isEqualTo []),
+        ["", "(target visible) "] select _vis,
         name _unit,
         round (_unit distance _pos)
     ] call FUNC(debugLog);

--- a/addons/main/functions/UnitAction/fnc_doAssaultMemory.sqf
+++ b/addons/main/functions/UnitAction/fnc_doAssaultMemory.sqf
@@ -44,8 +44,8 @@ if (
 };
 
 // sort positions from nearest to furthest prioritising positions on the same floor
-private _unitATL2 = round (getPosATL _unit select 2);
-_groupMemory = _groupMemory apply {[_unitATL2 isEqualTo (round (_x select 2)), _x distanceSqr _unit, _x]};
+private _unitASL2 = round ( ( getPosASL _unit ) select 2 );
+_groupMemory = _groupMemory apply {[_unitASL2 + (round ((AGLToASL _x) select 2)), _x distanceSqr _unit, _x]};
 _groupMemory sort true;
 _groupMemory = _groupMemory apply {_x select 2};
 
@@ -78,6 +78,7 @@ _unit setUnitPosWeak (["UP", "MIDDLE"] select (_indoor || {_distance2D > 8} || {
 if (_distance2D < 7) then {_unit setVariable ["ace_medical_ai_lastFired", CBA_missionTime];};
 
 // execute move
+_unit lookAt (_pos vectorAdd [0, 0, 1]);
 _unit doMove _pos;
 _unit setDestination [_pos, "LEADER PLANNED", _indoor];
 


### PR DESCRIPTION
Added breakout condition to doGroupAssault
Added movement check to doGroupAssault (makes movement more reliable against AI)
Added and fixed use of 'LookAt' to ensure troops are looking the right way!
Fixed floor selection algorithm in doGroupAssault and doAssaultMemory
Fixed getUnitState check order in doGroupAssault
Improved Increased time cycle for tacticsAssault to give troops more breathing room
Improved Increased cycle speed of doGroupAssault
Improved Slows down movement speeds in doGroupAssault for better shooting
Removed one groupMemory check in doGroupAssault