### PR TITLE
Add group settings for Attack, Reinforce and Dynamic Reinforcement

### DIFF
--- a/addons/danger/XEH_preInitClient.sqf
+++ b/addons/danger/XEH_preInitClient.sqf
@@ -10,7 +10,7 @@ Here four buttons are added:
 These functions and buttons could conceivably be moved to their own module.
 They might also benefit from added interface and more nuanced functions handling.
 That said: within the current scope of the AI mod. They can make a comfortable
-home here. Until revisited by more capable personnell.
+home here. Until revisited by more capable personell.
 - nkenny
 */
 
@@ -103,7 +103,7 @@ private _fnc_assault_AI = {
     } else {
         _cursorPos = getPos cursorObject;
     };
-    private _buildings = [_cursorPos, 50, true, false] call EFUNC(main,findBuildings);
+    private _buildings = [_cursorPos, 12, true, false] call EFUNC(main,findBuildings);
     (group player) setVariable [QEGVAR(main,groupMemory), _buildings];
     {
         private _enemy = _x findNearestEnemy _cursorPos;

--- a/addons/danger/settings.inc.sqf
+++ b/addons/danger/settings.inc.sqf
@@ -108,6 +108,70 @@ _curCat = LSTRING(Settings_GeneralCat);
     1
 ] call CBA_fnc_addSetting;
 
+addMissionEventHandler ["GroupCreated", {
+    params ["_group"];
+    [
+        {
+            if (count (units _this) > 0) then {
+                if (GVAR(autoAddDynamicReinforcement)) then {_this setVariable [QGVAR(enableGroupReinforce), true, true];};
+                if !(GVAR(disableAttackOverride)) then {_this enableAttack false;};
+                if (GVAR(disableFleeingOverride)) then {_this allowFleeing 0;};
+            };
+        },
+        _group,
+        3
+    ] call CBA_fnc_waitAndExecute;
+}];
+
+// auto disable enableAttack on groups
+[
+    QGVAR(disableAttackOverride),
+    "CHECKBOX",
+    [LSTRING(Settings_AttackOverride), LSTRING(Settings_AttackOverride_ToolTip)],
+    [COMPONENT_NAME, _curCat],
+    false,
+    false, {
+        params ["_value"];
+        if (_value) exitWith {};
+        if (!_value && time > 0) then {
+            {_x enableAttack false;} forEach (allGroups select {local (leader _x)});
+        };
+    }
+] call CBA_fnc_addSetting;
+
+// auto disable allowFleeing on groups
+[
+    QGVAR(disableFleeingOverride),
+    "CHECKBOX",
+    [LSTRING(Settings_FleeingOverride), LSTRING(Settings_FleeingOverride_ToolTip)],
+    [COMPONENT_NAME, _curCat],
+    false,
+    false, {
+        params ["_value"];
+        if (_value) exitWith {};
+        if (!_value && time > 0) then {
+            {_x allowFleeing 0;} forEach (allGroups select {local (leader _x)});
+        };
+    }
+] call CBA_fnc_addSetting;
+
+// auto add dynamic reinforcement
+[
+    QGVAR(autoAddDynamicReinforcement),
+    "CHECKBOX",
+    [LSTRING(Settings_UniversalDynamicReinforcement), LSTRING(Settings_UniversalDynamicReinforcement_ToolTip)],
+    [COMPONENT_NAME, _curCat],
+    false,
+    false, {
+        params ["_value"];
+        if (!_value) exitWith {};
+        if (_value) then {
+            {_x setVariable [QGVAR(enableGroupReinforce), true, true];} forEach (allGroups select {local (leader _x)});
+        };
+    }
+] call CBA_fnc_addSetting;
+
+
 /*
 TEMPORARILY DISABLED FOR VERSION 2.5 RELEASE
 WAITING BETTER OR OTHER SOLUTION

--- a/addons/danger/stringtable.xml
+++ b/addons/danger/stringtable.xml
@@ -422,5 +422,23 @@
             <Italian>Lamber Danger FSM</Italian>
             <Chinesesimp>Lambs Danger FSM</Chinesesimp>
         </Key>
+        <Key ID="STR_Lambs_Danger_Settings_AttackOverride">
+            <English>Disable LAMBS Attack Override</English>
+        </Key>
+        <Key ID="STR_Lambs_Danger_Settings_AttackOverride_ToolTip">
+            <English>LAMBS Danger.fsm introduces new attack patterns that in many cases replace vanilla options. If, for some reason, you want to keep the vanilla Attack cycle check this box.</English>
+        </Key>
+        <Key ID="STR_Lambs_Danger_Settings_UniversalDynamicReinforcement">
+            <English>Enable universal Dynamic Reinforcement</English>
+        </Key>
+        <Key ID="STR_Lambs_Danger_Settings_UniversalDynamicReinforcement_ToolTip">
+            <English>Enable this feature to apply Dynamic Reinforcement logic to all groups. This means all groups will respond to the Shared Information feature.\nBehaviours include: creating new waypoints, abandoning garrisons packing and claiming static weapons and vehicles.\nNB: This setting can dramatically alter missions. Use with care.</English>
+        </Key>
+        <Key ID="STR_Lambs_Danger_Settings_FleeingOverride">
+            <English>Disable vanilla fleeing feature</English>
+        </Key>
+        <Key ID="STR_Lambs_Danger_Settings_FleeingOverride_ToolTip">
+            <English>Chgecking this option prevents groups from initiating the default 'fleeing' mode. This can be particularly useful for ZEUS missions where the mission designer wants additional control of the group.\nThis setting is functionally identical with setting '(group) allowFleeing 0' in group inits</English>
+        </Key>
     </Package>
 </Project>


### PR DESCRIPTION
Adds universal group settings for Attack, Flight and Dynamic reinforcement

Disabling '_enableattack_' on groups has the benefit of giving us more control of group actions (less running away doing random shit).  The cost is that the AI will conduct fewer unit level flanking attacks. 