### PR TITLE
Enrich information of share information handlers

### DIFF
--- a/addons/main/functions/fnc_addShareInformationHandler.sqf
+++ b/addons/main/functions/fnc_addShareInformationHandler.sqf
@@ -13,6 +13,9 @@
  * 1: enemy target <OBJECT>
  * 2: range to share information, default 350 <NUMBER>
  * 3: override radio ranges, default false <BOOLEAN>
+ * 4: group member doing the actual radio call <OBJECT>
+ * 5: sharing range after adjusting for radio ranges <NUMBER> 	
+ * 6: unit has has a long range radio <BOOLEAN>
  *
  * Return Value:
  * None

--- a/addons/main/functions/fnc_doShareInformation.sqf
+++ b/addons/main/functions/fnc_doShareInformation.sqf
@@ -32,19 +32,19 @@ if (isNull _target) then {
     _target = _unit findNearestEnemy _unit;
 };
 
+// range
+([_unit, _range, _override] call FUNC(getShareInformationParams)) params ["_newUnit", "_newRange", "_radio"];
+
 // custom handlers
 private _stopShare = false;
 {
-    private _callbackResult = [_unit, _target, _range, _override] call _x;
+    private _callbackResult = [_unit, _target, _range, _override, _newUnit, _newRange, _radio] call _x;
     if (!(isNil "_callbackResult") && {_callbackResult isEqualTo true}) exitWith {_stopShare = true};
 } forEach GVAR(shareHandlers);
 if (_stopShare) exitWith {false};
 
 _unit setVariable [QGVAR(currentTarget), _target, GVAR(debug_functions)];
 //_unit setVariable [QGVAR(currentTask), "Share Information", GVAR(debug_functions)]; // do not update task -- sharing information is secondary info ~ nkenny
-
-// range
-([_unit, _range, _override] call FUNC(getShareInformationParams)) params ["_newUnit", "_newRange"];
 
 // find units
 private _group = group _newUnit;


### PR DESCRIPTION
In order to implement https://github.com/Crowdedlight/Crows-Electronic-Warfare/issues/43 some minor change to registration of **custom share handlers** via `lambs_main_fnc_addShareInformationHandler` is needed.

See also discussion on LAMBS Discord https://discord.com/channels/681656029758488619/681656029758488726/1409217733450535055

### When merged this pull request will:

1. Move the range correction of `FUNC(getShareInformationParams)` before checking all the `GVAR(shareHandlers)`.
2. `GVAR(shareHandlers)` will be supplied with 3 more parameters 
   - those that were returned by `FUNC(getShareInformationParams)`
3. add those new parameters in the function header of `fnc_addShareInformationHandler.sqf`

Tested using
```sqf
Type: Public
Build: Stable
Version: 2.20.152984
```

Let me know if you require addition to the Wiki as well.