### PR TITLE
Improve tactics flank and suppress actions

### DIFF
--- a/addons/danger/functions/fnc_tacticsAssess.sqf
+++ b/addons/danger/functions/fnc_tacticsAssess.sqf
@@ -250,7 +250,6 @@ _plan = selectRandom _plan;
 switch (_plan) do {
     case TACTICS_FLANK: {
         // flank
-        [{_this call FUNC(tacticsFlank)}, [_group, _pos, _units], 22 + random 8] call CBA_fnc_waitAndExecute;
         [{_this call FUNC(tacticsFlank)}, [_group, _pos], 22 + random 8] call CBA_fnc_waitAndExecute;
     };
     case TACTICS_GARRISON: {

--- a/addons/danger/functions/fnc_tacticsAssess.sqf
+++ b/addons/danger/functions/fnc_tacticsAssess.sqf
@@ -251,6 +251,7 @@ switch (_plan) do {
     case TACTICS_FLANK: {
         // flank
         [{_this call FUNC(tacticsFlank)}, [_group, _pos, _units], 22 + random 8] call CBA_fnc_waitAndExecute;
+        [{_this call FUNC(tacticsFlank)}, [_group, _pos], 22 + random 8] call CBA_fnc_waitAndExecute;
     };
     case TACTICS_GARRISON: {
         // garrison ~ nb units not carried here - nkenny
@@ -262,11 +263,11 @@ switch (_plan) do {
     };
     case TACTICS_SUPPRESS: {
         // suppress
-        [{_this call FUNC(tacticsSuppress)}, [_group, _pos, _units], 4 + random 4] call CBA_fnc_waitAndExecute;
+        [{_this call FUNC(tacticsSuppress)}, [_group, _pos], 2 + random 2] call CBA_fnc_waitAndExecute;
     };
     case TACTICS_ATTACK: {
         // group attacks as one
-        [{_this call FUNC(tacticsAttack)}, [_group, _pos, _units], 1 + random 1] call CBA_fnc_waitAndExecute;
+        [{_this call FUNC(tacticsAttack)}, [_group, _pos], 1 + random 1] call CBA_fnc_waitAndExecute;
     };
     default {
         // hide from armor

--- a/addons/danger/functions/fnc_tacticsSuppress.sqf
+++ b/addons/danger/functions/fnc_tacticsSuppress.sqf
@@ -17,7 +17,7 @@
  *
  * Public: No
 */
-params ["_group", "_target", ["_units", []], ["_delay", 17]];
+params ["_group", "_target", ["_units", []], ["_delay", 45]];
 
 // group is missing
 if (isNull _group) exitWith {false};
@@ -38,22 +38,27 @@ if !([_unit, (ATLToASL _target) vectorAdd [0, 0, 5]] call EFUNC(main,shouldSuppr
     [_group, _target] call FUNC(tacticsFlank);
 };
 
-// sort cycles
-private _cycle = selectRandom [2, 3, 3, 4];
-
 // reset tactics
+_group setVariable [QGVAR(isExecutingTactic), true];
 [
     {
-        params ["_group", "_enableAttack"];
+        params [["_group", grpNull], ["_delay", 0]];
+        time > _delay || {isNull _group} || { !(_group getVariable [QGVAR(isExecutingTactic), false]) }
+    },
+    {
+        params ["_group", "", ["_enableAttack", false], ["_formation", "WEDGE"]];
         if (!isNull _group) then {
             _group setVariable [QGVAR(isExecutingTactic), nil];
-            _group enableAttack _enableAttack;
             _group setVariable [QEGVAR(main,currentTactic), nil];
+            _group enableAttack _enableAttack;
+            {
+                _x setVariable [QEGVAR(main,currentTask), nil, EGVAR(main,debug_functions)];
+                _x doFollow (leader _x);
+            } forEach (units _group);
         };
     },
-    [group _unit, attackEnabled _unit],
-    _delay * _cycle
-] call CBA_fnc_waitAndExecute;
+    [group _unit, time + _delay, attackEnabled _unit, formation _group]
+] call CBA_fnc_waitUntilAndExecute;
 
 // alive unit
 if !(_unit call EFUNC(main,isAlive)) exitWith {false};
@@ -64,13 +69,13 @@ if (_units isEqualTo []) then {
 };
 if (_units isEqualTo []) exitWith {false};
 
-// find vehicles
-private _vehicles = [_unit] call EFUNC(main,findReadyVehicles);
+// find vehicles with weapons
+private _vehicles = ([_unit] call EFUNC(main,findReadyVehicles)) select {someAmmo _x};
 
 // sort building locations
-private _pos = [_target, 20, true, false] call EFUNC(main,findBuildings);
-_pos append ((nearestTerrainObjects [ _target, ["HIDE", "TREE", "BUSH", "SMALL TREE"], 8, false, true]) apply { (getPosATL _x) vectorAdd [0, 0, random 2] });
-_pos pushBack _target;
+private _postList = [_target, 20, true, false] call EFUNC(main,findBuildings);
+_postList append ((nearestTerrainObjects [ _target, ["HIDE", "TREE", "BUSH", "SMALL TREE"], 8, false, true]) apply { (getPosATL _x) vectorAdd [0, 0, random 2] });
+_postList pushBack _target;
 
 // set tasks
 _unit setVariable [QEGVAR(main,currentTarget), _target, EGVAR(main,debug_functions)];
@@ -79,6 +84,7 @@ _unit setVariable [QEGVAR(main,currentTask), "Leader Suppress", EGVAR(main,debug
 // set group task
 _group = group _unit;
 _group enableAttack false;
+_group setFormation "LINE";
 _group setVariable [QEGVAR(main,currentTactic), "Suppressing", EGVAR(main,debug_functions)];
 
 // gesture
@@ -91,11 +97,11 @@ _group setVariable [QEGVAR(main,currentTactic), "Suppressing", EGVAR(main,debug_
 _group setFormDir (_unit getDir _target);
 
 // execute recursive cycle
-[_cycle, _units, _vehicles, _pos] call EFUNC(main,doGroupSuppress);
+ [{_this call EFUNC(main,doGroupSuppress)}, [_group, _units, _vehicles, _postList], 1 + random 1] call CBA_fnc_waitAndExecute;
 
 // debug
 if (EGVAR(main,debug_functions)) then {
-    ["%1 TACTICS SUPPRESS (%2 with %3 units and %6 vehicles @ %4m with %5 positions for %7 cycles)", side _unit, name _unit, count _units, round (_unit distance2D _target), count _pos, count _vehicles, _cycle] call EFUNC(main,debugLog);
+    ["%1 TACTICS SUPPRESS (%2 with %3 units and %6 vehicles @ %4m with %5 positions)", side _unit, name _unit, count _units, round (_unit distance2D _target), count _postList, count _vehicles] call EFUNC(main,debugLog);
     private _m = [_unit, "tactics suppress", _unit call EFUNC(main,debugMarkerColor), "hd_arrow"] call EFUNC(main,dotMarker);
     private _mt = [_target, "", _unit call EFUNC(main,debugMarkerColor), "hd_destroy"] call EFUNC(main,dotMarker);
     {_x setMarkerSizeLocal [0.6, 0.6];} forEach [_m, _mt];

--- a/addons/main/XEH_PREP.hpp
+++ b/addons/main/XEH_PREP.hpp
@@ -8,6 +8,7 @@ PREP(doShareInformation);
 PREP(getLauncherUnits);
 PREP(getShareInformationParams);
 PREP(shouldSuppressPosition);
+PREP(checkVisibilityList);
 
 PREP(eventCallback);
 PREP(findBuildings);

--- a/addons/main/functions/GroupAction/fnc_doGroupFlank.sqf
+++ b/addons/main/functions/GroupAction/fnc_doGroupFlank.sqf
@@ -4,7 +4,7 @@
  * Actualises flanking cycle
  *
  * Arguments:
- * 0: cycles <NUMBER>
+ * 0: group conducting the flanking <GROUP>
  * 1: units list <ARRAY>
  * 2: list of group vehicles <ARRAY>
  * 3: list of building/enemy positions <ARRAY>
@@ -18,11 +18,21 @@
  *
  * Public: No
 */
-params ["_cycle", "_units", "_vehicles", "_pos", "_overwatch", ["_teamAlpha", 0]];
+params [["_group", grpNull], ["_units", []], ["_vehicles", []], ["_posList", []], ["_overwatch", [0, 0, 0]], ["_teamAlpha", 0]];
+
+// exit!
+if !(_group getVariable [QEGVAR(danger,isExecutingTactic), false]) exitWith {false};
 
 // update
-_units = _units select { _x call FUNC(isAlive) && { !isPlayer _x } && {_x distance2D _overwatch > 5}};
+_units = _units select { !( _x getVariable [QEGVAR(danger,disableAI), false] ) && { _x call FUNC(isAlive) } && { !isPlayer _x } };
 _vehicles = _vehicles select { canFire _x };
+
+// group has reached destination
+private _leader = leader _group;
+if ( _leader distance2D _overwatch < 4 ) exitWith {
+    _group setVariable [QEGVAR(danger,isExecutingTactic), false];
+    _group setVariable [QGVAR(groupMemory), _posList, false];
+};
 
 {
     private _suppressed = (getSuppression _x) > 0.5;
@@ -32,14 +42,19 @@ _vehicles = _vehicles select { canFire _x };
     _x doMove (_overwatch vectorAdd [-2 + random 4, -2 + random 4, 0]);
     _x setDestination [_overwatch, "LEADER PLANNED", true];
     _x setVariable [QEGVAR(danger,forceMove), !_suppressed];
+    _x setVariable [QGVAR(currentTask), "Group Flank", GVAR(debug_functions)];
 
     // suppress
-    private _posASL = AGLToASL (selectRandom _pos);
+    private _posASL = AGLToASL (selectRandom _posList);
+    private _eyePos = eyePos _x;
+    _posASL = _eyePos vectorAdd ((_posASL vectorDiff _eyePos) vectorMultiply 0.6);
+
     if (
         (_forEachIndex % 2) isEqualTo _teamAlpha
-        && {!(terrainIntersectASL [eyePos _x, _posASL vectorAdd [0, 0, 3]])}
+        && {_x isNotEqualTo (leader _x)}
+        && {[_x, "VIEW", objNull] checkVisibility [_eyePos, _posASL] isEqualTo 1}
     ) then {
-        [{_this call FUNC(doSuppress)}, [_x, _posASL vectorAdd [0, 0, random 1], true], 1 + random 3] call CBA_fnc_waitAndExecute;
+        [{_this call FUNC(doSuppress)}, [_x, _posASL vectorAdd [0, 0, random 1], true], random 1] call CBA_fnc_waitAndExecute;
     };
 } forEach _units;
 
@@ -47,24 +62,40 @@ _vehicles = _vehicles select { canFire _x };
 _teamAlpha = parseNumber (_teamAlpha isEqualTo 0);
 
 // vehicles
-if ((_cycle % 2) isEqualTo 0) then {
-    {
-        private _posAGL = selectRandom _pos;
-        _x doWatch _posAGL;
-        [_x, _posAGL] call FUNC(doVehicleSuppress);
-    } forEach _vehicles;
-} else {
-    // check for roads
-    private _roads = _overwatch nearRoads 50;
-    if (_roads isNotEqualTo []) exitWith {_vehicles doMove (ASLToAGL (getPosASL (selectRandom _roads)));};
-    _vehicles doMove _overwatch;
-};
+_vehicles doWatch (selectRandom _posList);
+{
+
+    // sort out vehicles
+    [_posList, true] call CBA_fnc_shuffle;
+    private _index = [_x, _posList] call FUNC(checkVisibilityList);
+
+    if (_index isEqualTo -1) then {
+
+        // loaded vehicles move quickly
+        if (count crew _x > 3) exitWith {_x doMove _overwatch;};
+
+        // move up behind leader
+        private _leaderPos = _leader getPos [35 min (_leader distance2D _x), _overwatch getDir _leader];
+        if ((vehicle _leader) isEqualTo _x) then {_leaderPos = _x getPos [35, _x getDir _overwatch]};
+
+        // check for roads
+        private _roads = _leaderPos nearRoads 50;
+        if (_roads isNotEqualTo []) exitWith {_x doMove (ASLToAGL (getPosASL (selectRandom _roads)));};
+        _x doMove _leaderPos;
+
+    } else {
+
+        // do suppressive fire
+        [_x, _posList select _index] call FUNC(doVehicleSuppress);
+    };
+}
+forEach (_vehicles select {(currentCommand _x) isNotEqualTo "Suppress"});
 
 // recursive cyclic
-if !(_cycle <= 1 || {_units isEqualTo []}) then {
+if (_units isNotEqualTo [] && { _group getVariable [QEGVAR(danger,isExecutingTactic), false] }) then {
     [
         {_this call FUNC(doGroupFlank)},
-        [_cycle - 1, _units, _vehicles, _pos, _overwatch, _teamAlpha],
+        [_group, _units, _vehicles, _posList, _overwatch, _teamAlpha],
         10 + random 8
     ] call CBA_fnc_waitAndExecute;
 };

--- a/addons/main/functions/GroupAction/fnc_doGroupSuppress.sqf
+++ b/addons/main/functions/GroupAction/fnc_doGroupSuppress.sqf
@@ -4,7 +4,7 @@
  * Actualisation of Suppression cycle
  *
  * Arguments:
- * 0: cycles <NUMBER>
+ * 0: group conducting the suppression <GROUP>
  * 1: units list <ARRAY>
  * 2: list of group vehicles <ARRAY>
  * 3: list of building/enemy positions <ARRAY>
@@ -17,58 +17,80 @@
  *
  * Public: No
 */
-params ["_cycle", "_units", "_vehicles", "_pos"];
+params [["_group", grpNull], ["_units", []], ["_vehicles", []], ["_posList", []]];
+
+// exit!
+if !(_group getVariable [QEGVAR(danger,isExecutingTactic), false]) exitWith {false};
 
 // update
-_units = _units select {_x call FUNC(isAlive) && { !isPlayer _x }};
+_units = _units select { !( _x getVariable [QEGVAR(danger,disableAI), false] ) && { _x call FUNC(isAlive) } && { !isPlayer _x } };
 _vehicles = _vehicles select { canFire _x };
+
+// get leader
+private _leader = leader _group;
 
 // infantry
 {
-    // ready
-    private _posAGL = selectRandom _pos;
-    _posAGL = _posAGL vectorAdd [0, 0, random 1];
+    // find target
+    [_posList, true] call CBA_fnc_shuffle;
+    private _index = [_x, _posList] call FUNC(checkVisibilityList);
 
-    // suppressive fire
-    _x forceSpeed 1;
-    _x setUnitPosWeak "MIDDLE";
-    private _suppress = [_x, AGLToASL _posAGL] call FUNC(doSuppress);
-    _x setVariable [QGVAR(currentTask), "Group Suppress", GVAR(debug_functions)];
+    // execute suppression
+    if (
+        _index isNotEqualTo -1
+    ) then {
 
-    // no LOS
-    if !(_suppress || {(currentCommand _x isEqualTo "Suppress")}) then {
+        // suppressive fire
+        _x forceSpeed 1;
+        _x setUnitPosWeak "MIDDLE";
+        [_x, AGLToASL ((_posList select _index) vectorAdd [0, 0, random 1])] call FUNC(doSuppress);
+        _x setVariable [QGVAR(currentTask), "Group Suppress", GVAR(debug_functions)];
+
+    } else {
+
         // move forward
         _x forceSpeed 3;
-        _x doMove (_x getPos [20, _x getDir _posAGL]);
+        _x doMove (_x getPos [20, _x getDir (_posList select -1)]);
         _x setVariable [QGVAR(currentTask), "Group Suppress (Move)", GVAR(debug_functions)];
-    };
 
-    // follow-up fire
-    [
-        {
-            params ["_unit", "_posASL"];
-            if (_unit call FUNC(isAlive) && {(currentCommand _unit isNotEqualTo "Suppress")}) then {
-                [_unit, _posASL vectorAdd [2 - random 4, 2 - random 4, 0.8], true] call EFUNC(main,doSuppress);
-            };
-        },
-        [_x, AGLToASL _posAGL],
-        5
-    ] call CBA_fnc_waitAndExecute;
-} forEach _units;
+    };
+} forEach (_units select {(currentCommand _x) isNotEqualTo "Suppress"});
 
 // vehicles
 {
-    private _posAGL = selectRandom _pos;
-    _x doWatch _posAGL;
-    [_x, _posAGL] call FUNC(doVehicleSuppress);
-} forEach _vehicles;
+
+    // find target
+    private _index = [_x, _posList] call FUNC(checkVisibilityList);
+
+    // execute suppression
+    if (
+        _index isNotEqualTo -1
+    ) then {
+
+        // vehicle suppress
+        [_x, (_posList select _index) vectorAdd [0, 0, random 1]] call FUNC(doVehicleSuppress);
+
+    } else {
+
+        // move up behind leader
+        _x doWatch (selectRandom _posList);
+        private _leaderPos = _leader getPos [35 min (_x distance2D _leader), _overwatch getDir _leader];
+
+        // check for roads
+        private _roads = _leaderPos nearRoads 50;
+        if (_roads isNotEqualTo []) exitWith {_x doMove (ASLToAGL (getPosASL (selectRandom _roads)));};
+        _x doMove _leaderPos;
+
+    };
+
+} forEach (_vehicles select {(currentCommand _x) isNotEqualTo "Suppress"});
 
 // recursive cyclic
-if !(_cycle <= 1 || {_units isEqualTo []}) then {
+if (_units isNotEqualTo [] && { _group getVariable [QEGVAR(danger,isExecutingTactic), false] }) then {
     [
         {_this call FUNC(doGroupSuppress)},
-        [_cycle - 1, _units, _vehicles, _pos],
-        16 + random 2
+        [_group, _units, _vehicles, _posList],
+        6 + random 2
     ] call CBA_fnc_waitAndExecute;
 };
 

--- a/addons/main/functions/fnc_checkVisibilityList.sqf
+++ b/addons/main/functions/fnc_checkVisibilityList.sqf
@@ -1,0 +1,31 @@
+#include "script_component.hpp"
+/*
+ * Author: nkenny
+ * Find a location a unit can see from a list of position AGL
+ *
+ * Arguments:
+ * 0: Unit doing looking <OBJECT>
+ * 1: Array of possible locations in AGL <ARRAY>
+ *
+ * Return Value:
+ * index
+ *
+ * Example:
+ * [bob, []] call lambs_main_fnc_checkVisibilityList;
+ *
+ * Public: Yes
+*/
+
+params [["_unit", objNull], ["_posList", []]];
+
+private _eyePos = eyePos (vehicle _unit);
+private _return = _posList findIf {
+
+    // get variables
+    private _posASL = AGLToASL _x;
+    _posASL = _eyePos vectorAdd ((_posASL vectorDiff _eyePos) vectorMultiply 0.6);
+
+    // check visibility
+    [vehicle _unit, "VIEW", objNull] checkVisibility [_eyePos, _posASL] isEqualTo 1
+};
+_return


### PR DESCRIPTION
This pull request adds better exit conditions to suppression and flanking group actions-- and makes these actions more reliable in terms of handling vehicles, picking suppression targets, and actual movement. Some of the introduced changes will make #442 redundant. 

In practice this means mission makers can interrupt group level tactical actions at any time. Fitting something like this code into the mod or a mission will also allow ZEUS players to interrupt ongoing tactics and issue new movement orders. 

```

["ModuleCurator_F", "init", {

    (_this select 0) addEventHandler ["CuratorWaypointPlaced", {
        params ["_curator", "_group", "_waypointID"];

        // update variables
        _group setVariable [QEGVAR(danger,isExecutingTactic), false, true];
        _group setVariable [QEGVAR(main,groupMemory), [], true];

        // clear targets
        private _leader = leader _group;
        private _waypointPos = getWPPos [_group, _waypointID];

        // forget enemies that are distant to waypoint
        if (local _leader && {_leader distance2D _waypointPos > 300}) then {

            private _enemies = (_leader targets [true]) select {_x distance2D _wayPointPos > 300};
            {
                _group forgetTarget _x;
            } forEach _enemies;
        };
    }];
}, true, [], true] call CBA_fnc_addClassEventHandler;

```



----

**danger\fnc_tacticsAssess.sqf**
 - Tweaks timings.
 - Removes _units. This makes the functions more flexible.

**danger\fnc_tacticsFlank.sqf**
- Adds exit condition to tactic check
- Adds more positions to shoot at
- Adds better handling of vehicles and their cargo
- Changes previous variable name "_pos" to "_posList" to better distinguish it.

**danger\fnc_tacticsSuppress.sqf**
- Adds exit condition to tactic check
- Changes previous variable name "_pos" to "_posList"

**main\fnc_checkVisibilityList.sqf**
- Adds a new checkVisibilityList function to pick better suppression targets from a list

**main\group\fnc_doGroupFlank.sqf**
- Adds exit conditions
- Improves vehicle suppression and movement reliability
- Changes previous variable name "_pos" to "_posList"


**main\group\fnc_doGroupSuppress.sqf**
- Adds exit conditions
- Adds more robust suppression target selection to both infantry and vehicles
- Changes previous variable name "_pos" to "_posList"

