### PR TITLE
Make search, assault and cqb tasks more resilient to locality changes

### DIFF
--- a/addons/wp/functions/fnc_taskAssault.sqf
+++ b/addons/wp/functions/fnc_taskAssault.sqf
@@ -119,6 +119,15 @@ _group setFormation "LINE";
             {
                 params ["_args", "_handle"];
                 _args params ["_unit", "_group", "_retreat", "_threshold"];
+                if !(local _unit) exitWith {
+                    _handle call CBA_fnc_removePerFrameHandler;
+                    _unit setVariable [QGVAR(taskAssault), nil];
+
+                    // group
+                    private _groupMembers = _group getVariable [QGVAR(taskAssaultMembers), []];
+                    _group setVariable [QGVAR(taskAssaultMembers), _groupMembers - [_unit]];
+                };
+
                 private _destination = (_group getVariable [QGVAR(taskAssaultDestination), getPos _unit]) call CBA_fnc_getPos;
 
                 // exit
@@ -161,6 +170,11 @@ _group setFormation "LINE";
 
 // execute move
 waitUntil {
+
+    if !(local leader _group) exitWith {
+        [QGVAR(taskAssault), _this, leader _group] call CBA_fnc_targetEvent;
+        true
+    };
 
     // reset option
     if ((units _group) isEqualTo []) exitWith {true};
@@ -212,6 +226,11 @@ waitUntil {
 // clean up
 _group setVariable [QGVAR(taskAssaultDestination), nil];
 _group setVariable [QGVAR(taskAssaultMembers), nil];
+
+if !(local leader _group) exitWith {
+    false
+};
+
 _group setFormation "WEDGE";
 _group setBehaviour "AWARE";
 _group setCombatMode "YELLOW";

--- a/addons/wp/functions/fnc_taskCQB.sqf
+++ b/addons/wp/functions/fnc_taskCQB.sqf
@@ -197,6 +197,11 @@ waitUntil {
     // performance
     waitUntil {sleep 1; simulationEnabled (leader _group)};
 
+    if !(local leader _group) exitWith {
+        [QGVAR(taskCQB), _this, leader _group] call CBA_fnc_targetEvent;
+        true
+    };
+
     // get wp position
     private _wPos = _pos call CBA_fnc_getPos;
 
@@ -227,6 +232,10 @@ waitUntil {
     _x setUnitPos "AUTO";
     _x doFollow (leader _x);
 } forEach units _group;
+
+if !(local leader _group) exitWith {
+    false
+};
 
 // debug
 if (EGVAR(main,debug_functions)) then {["%1 taskCQB: CQB DONE version 0.3", side _group] call EFUNC(main,debugLog);};

--- a/addons/wp/functions/fnc_taskCreep.sqf
+++ b/addons/wp/functions/fnc_taskCreep.sqf
@@ -114,6 +114,11 @@ waitUntil {
     // performance
     waitUntil {sleep 1; simulationEnabled leader _group};
 
+    if !(local leader _group) exitWith {
+        [QGVAR(taskCreep), _this, leader _group] call CBA_fnc_targetEvent;
+        true
+    };
+
     // find
     private _target = [_group, _radius, _area, _pos, _onlyPlayers] call EFUNC(main,findClosestTarget);
 
@@ -133,4 +138,4 @@ waitUntil {
 };
 
 // end
-true
+local leader _group

--- a/addons/wp/functions/fnc_taskHunt.sqf
+++ b/addons/wp/functions/fnc_taskHunt.sqf
@@ -85,6 +85,11 @@ waitUntil {
     // performance
     waitUntil { sleep 1; simulationEnabled (leader _group) };
 
+    if !(local leader _group) exitWith {
+        [QGVAR(taskHunt), _this, leader _group] call CBA_fnc_targetEvent;
+        true
+    };
+
     // find
     private _target = [_group, _radius, _area, _pos, _onlyPlayers] call EFUNC(main,findClosestTarget);
 
@@ -113,4 +118,4 @@ waitUntil {
 };
 
 // end
-true
+local leader _group

--- a/addons/wp/functions/fnc_taskRush.sqf
+++ b/addons/wp/functions/fnc_taskRush.sqf
@@ -127,6 +127,11 @@ waitUntil {
     // performance
     waitUntil { sleep 1; simulationEnabled (leader _group); };
 
+    if !(local leader _group) exitWith {
+        [QGVAR(taskRush), _this, leader _group] call CBA_fnc_targetEvent;
+        true
+    };
+
     // find
     private _target = [_group, _radius, _area, _pos, _onlyPlayers] call EFUNC(main,findClosestTarget);
 
@@ -145,4 +150,4 @@ waitUntil {
 };
 
 // end
-true
+local leader _group

--- a/addons/wp/functions/fnc_taskRush.sqf
+++ b/addons/wp/functions/fnc_taskRush.sqf
@@ -149,5 +149,16 @@ waitUntil {
 
 };
 
+if !(local leader _group) exitWith {
+    {
+        private _unit = _x;
+        {
+            _unit removeEventHandler [_x select 0, _x select 1];
+        } forEach (_unit getVariable [QGVAR(eventhandlers), [["Fired", -1], ["Suppressed", -1]]]);
+        _unit setVariable [QGVAR(eventhandlers), nil];
+    } forEach (units _group);
+    false
+};
+
 // end
-local leader _group
+true


### PR DESCRIPTION
### When merged this pull request will:

1. Make search, assault and cqb tasks look for locality change when running
2. Exit task and reroute to where leader is now local to
