### PR TITLE
Fix typo in ZEN context menu

### DIFF
--- a/addons/danger/stringtable.xml
+++ b/addons/danger/stringtable.xml
@@ -110,11 +110,11 @@
         <Key ID="STR_Lambs_Danger_Context_Main_DisplayName">
             <English>LAMBS Danger FSM</English>
             <Czech>LAMBS Danger FSM</Czech>
-            <Italian>Lamber Danger FSM</Italian>
+            <Italian>LAMBS Danger FSM</Italian>
             <Polish>LAMBS Danger FSM</Polish>
             <Russian>LAMBS Danger FSM</Russian>
             <German>LAMBS Danger FSM</German>
-            <Chinesesimp>Lambs Danger FSM</Chinesesimp>
+            <Chinesesimp>LAMBS Danger FSM</Chinesesimp>
         </Key>
         <Key ID="STR_Lambs_Danger_Module_ConfigureGroupAI_DisplayName">
             <English>Configure Group AI</English>

--- a/addons/danger/stringtable.xml
+++ b/addons/danger/stringtable.xml
@@ -108,7 +108,7 @@
             <Chinesesimp>拥有无线电</Chinesesimp>
         </Key>
         <Key ID="STR_Lambs_Danger_Context_Main_DisplayName">
-            <English>Lamber Danger FSM</English>
+            <English>LAMBS Danger FSM</English>
             <Czech>LAMBS Danger FSM</Czech>
             <Italian>Lamber Danger FSM</Italian>
             <Polish>LAMBS Danger FSM</Polish>


### PR DESCRIPTION
### When merged this pull request will:

1. title
2. lol
