### PR TITLE
Per-Side Dynamic Reinforcement 

### DIFF
--- a/addons/danger/XEH_PREP.hpp
+++ b/addons/danger/XEH_PREP.hpp
@@ -10,6 +10,7 @@ PREP(fsmAllowAnimation);
 PREP(isForced);
 PREP(isForcedExit);
 PREP(isLeader);
+PREP(setDynamicReinforcement);
 
 PREP(contact);
 

--- a/addons/danger/XEH_postInit.sqf
+++ b/addons/danger/XEH_postInit.sqf
@@ -19,3 +19,16 @@
     [_this select 0, QGVAR(OnReinforce), _this] call BIS_fnc_callScriptedEventHandler;
     [_this select 1, QGVAR(OnReinforce), _this] call BIS_fnc_callScriptedEventHandler;
 }] call CBA_fnc_addEventHandler;
+
+if (isServer) then {
+    {
+        [_x] call FUNC(setDynamicReinforcement);
+    } forEach allUnits;
+
+    addMissionEventHandler ["EntityCreated", {
+        params [["_entity", objNull, [objNull]]];
+        if (_entity isKindOf "CAManBase") then {
+            [_entity] call FUNC(setDynamicReinforcement);
+        };
+    }];
+};

--- a/addons/danger/XEH_preInit.sqf
+++ b/addons/danger/XEH_preInit.sqf
@@ -62,8 +62,9 @@ if (isNil QGVAR(dangerUntil)) then {
         private _adjustPos = _pos findEmptyPosition [5, 35, "Land_BagBunker_Large_F"];
         if (_adjustPos isNotEqualTo []) then {_pos = _adjustPos;};
 
+        private _fnc = FUNC(tacticsReinforce);
         {
-            [leader _x, _pos] call FUNC(tacticsReinforce);
+            [leader _x, _pos] spawn _fnc;
         } forEach _reinforceGroups;
     };
 

--- a/addons/danger/XEH_preInit.sqf
+++ b/addons/danger/XEH_preInit.sqf
@@ -32,7 +32,8 @@ if (isNil QGVAR(dangerUntil)) then {
 // EH handling reinforcement and combat mode
 [QEGVAR(main,OnInformationShared), {
     params [["_unit", objNull], "", ["_target", objNull], ["_groups", []]];
-    private _sideGroups = _groups select {(side _x) isEqualTo (side _unit)};
+    private _sideUnit = side _unit;
+    private _sideGroups = _groups select {(side _x) isEqualTo _sideUnit};
 
     // reinforce
     if (!isNull _target) then {

--- a/addons/danger/XEH_preInit.sqf
+++ b/addons/danger/XEH_preInit.sqf
@@ -32,28 +32,44 @@ if (isNil QGVAR(dangerUntil)) then {
 // EH handling reinforcement and combat mode
 [QEGVAR(main,OnInformationShared), {
     params [["_unit", objNull], "", ["_target", objNull], ["_groups", []]];
+    private _sideGroups = _groups select {(side _x) isEqualTo (side _unit)};
+
+    // reinforce
+    if (!isNull _target) then {
+        private _reinforceGroups = _sideGroups select {
+            private _leader = leader _x;
+            local _leader
+            && {_x getVariable [QGVAR(enableGroupReinforce), false]}
+            && {(_x getVariable [QGVAR(enableGroupReinforceTime), -1]) < time}
+        };
+
+        private _maxGroups = GVAR(maxReinforcementGroups);
+        if (
+            _maxGroups > 0
+            && {(count _reinforceGroups) > _maxGroups}
+        ) then {
+            _reinforceGroups = [_reinforceGroups, [], {leader _x distance2D _unit}, "ASCEND"] call BIS_fnc_sortBy;
+            _reinforceGroups resize _maxGroups;
+        };
+
+        // get pos of enemy if available
+        private _pos = [getPosASL _unit, (_unit targetKnowledge _target) select 6] select (_unit knowsAbout _target > 1.5);
+
+        // check for zero pos
+        if (_pos isEqualTo [0, 0, 0]) then {_pos = getPosASL _unit;};
+
+        // find free space
+        private _adjustPos = _pos findEmptyPosition [5, 35, "Land_BagBunker_Large_F"];
+        if (_adjustPos isNotEqualTo []) then {_pos = _adjustPos;};
+
+        {
+            [leader _x, _pos] call FUNC(tacticsReinforce);
+        } forEach _reinforceGroups;
+    };
+
     {
         private _leader = leader _x;
         if (local _leader) then {
-            // reinforce
-            if (
-                !isNull _target
-                && {_x getVariable [QGVAR(enableGroupReinforce), false]}
-                && {(_x getVariable [QGVAR(enableGroupReinforceTime), -1]) < time }
-            ) then {
-                
-                // get pos of enemy if available
-                private _pos = [getPosASL _unit, (_unit targetKnowledge _target) select 6] select (_unit knowsAbout _target > 1.5);
-
-                // check for zero pos
-                if (_pos isEqualTo [0, 0, 0]) then {_pos = getPosASL _unit;};
-                
-                // find free space
-                private _adjustPos = _pos findEmptyPosition [5, 35, "Land_BagBunker_Large_F"];
-                if (_adjustPos isNotEqualTo []) then {_pos = _adjustPos;};
-                [_leader, _pos] call FUNC(tacticsReinforce);
-            };
-
             // reorientate group
             if (
                 !(_leader getVariable [QGVAR(disableAI), false])
@@ -63,7 +79,7 @@ if (isNil QGVAR(dangerUntil)) then {
                 _x setFormDir (_leader getDir _unit);
             };
         };
-    } forEach (_groups select {(side _x) isEqualTo (side _unit)});
+    } forEach _sideGroups;
 }] call CBA_fnc_addEventHandler;
 
 ADDON = true;

--- a/addons/danger/functions/fnc_setDynamicReinforcement.sqf
+++ b/addons/danger/functions/fnc_setDynamicReinforcement.sqf
@@ -1,0 +1,31 @@
+#include "script_component.hpp"
+/*
+ * Author: LAMBS + Codex
+ * Enables dynamic reinforcement for newly initialized units per side based on CBA settings.
+ *
+ * Arguments:
+ * 0: unit <OBJECT>
+ *
+ * Return Value:
+ * None
+ *
+ * Public: No
+*/
+params [["_unit", objNull, [objNull]]];
+
+if (
+    isNull _unit
+    || {!alive _unit}
+    || {!(_unit isKindOf "CAManBase")}
+) exitWith {};
+
+private _enabled = switch (side group _unit) do {
+    case west: {GVAR(dynamicReinforcementWest)};
+    case east: {GVAR(dynamicReinforcementEast)};
+    case independent: {GVAR(dynamicReinforcementIndependent)};
+    default {false};
+};
+
+if (_enabled) then {
+    (group _unit) setVariable [QGVAR(enableGroupReinforce), true, true];
+};

--- a/addons/danger/settings.inc.sqf
+++ b/addons/danger/settings.inc.sqf
@@ -84,6 +84,36 @@ private _curCat = ELSTRING(main,Settings_MainCat);
     0
 ] call CBA_fnc_addSetting;
 
+// Automatically enable dynamic reinforcements for spawned WEST groups
+[
+    QGVAR(dynamicReinforcementWest),
+    "CHECKBOX",
+    [LSTRING(Settings_DynamicReinforcementWest), LSTRING(Settings_DynamicReinforcementWest_ToolTip)],
+    [COMPONENT_NAME, _curCat],
+    false,
+    1
+] call CBA_fnc_addSetting;
+
+// Automatically enable dynamic reinforcements for spawned EAST groups
+[
+    QGVAR(dynamicReinforcementEast),
+    "CHECKBOX",
+    [LSTRING(Settings_DynamicReinforcementEast), LSTRING(Settings_DynamicReinforcementEast_ToolTip)],
+    [COMPONENT_NAME, _curCat],
+    false,
+    1
+] call CBA_fnc_addSetting;
+
+// Automatically enable dynamic reinforcements for spawned INDEPENDENT groups
+[
+    QGVAR(dynamicReinforcementIndependent),
+    "CHECKBOX",
+    [LSTRING(Settings_DynamicReinforcementIndependent), LSTRING(Settings_DynamicReinforcementIndependent_ToolTip)],
+    [COMPONENT_NAME, _curCat],
+    false,
+    1
+] call CBA_fnc_addSetting;
+
 
 _curCat = LSTRING(Settings_GeneralCat);
 

--- a/addons/danger/settings.inc.sqf
+++ b/addons/danger/settings.inc.sqf
@@ -84,6 +84,16 @@ private _curCat = ELSTRING(main,Settings_MainCat);
     0
 ] call CBA_fnc_addSetting;
 
+// Limits number of groups called for reinforcement per information-sharing event. 0 means unlimited.
+[
+    QGVAR(maxReinforcementGroups),
+    "SLIDER",
+    [LSTRING(Settings_MaxReinforcementGroups), LSTRING(Settings_MaxReinforcementGroups_ToolTip)],
+    [COMPONENT_NAME, _curCat],
+    [0, 20, 0, 0],
+    1
+] call CBA_fnc_addSetting;
+
 // Automatically enable dynamic reinforcements for spawned WEST groups
 [
     QGVAR(dynamicReinforcementWest),

--- a/addons/danger/stringtable.xml
+++ b/addons/danger/stringtable.xml
@@ -377,6 +377,12 @@
             <German>Schaltet das verdeckte Bewegen von KI für Einheiten, die keine Ausrüstung zu Panzerabwehr oder Flugzeugabwehr besitzen, um. Durch das Ausschalten reagieren die Einheiten schneller.</German>
             <Chinesesimp>切换AI对未配备坦克和飞机的单位的隐藏动作.禁用此设置将使小组反应更激烈</Chinesesimp>
         </Key>
+        <Key ID="STR_Lambs_Danger_Settings_MaxReinforcementGroups">
+            <English>Max reinforcement groups per call</English>
+        </Key>
+        <Key ID="STR_Lambs_Danger_Settings_MaxReinforcementGroups_ToolTip">
+            <English>Limits how many eligible groups are ordered to reinforce per information-sharing event. Set to 0 for unlimited.</English>
+        </Key>
         <Key ID="STR_Lambs_Danger_Settings_DynamicReinforcementWest">
             <English>Auto-enable reinforcement for WEST</English>
         </Key>

--- a/addons/danger/stringtable.xml
+++ b/addons/danger/stringtable.xml
@@ -377,6 +377,24 @@
             <German>Schaltet das verdeckte Bewegen von KI für Einheiten, die keine Ausrüstung zu Panzerabwehr oder Flugzeugabwehr besitzen, um. Durch das Ausschalten reagieren die Einheiten schneller.</German>
             <Chinesesimp>切换AI对未配备坦克和飞机的单位的隐藏动作.禁用此设置将使小组反应更激烈</Chinesesimp>
         </Key>
+        <Key ID="STR_Lambs_Danger_Settings_DynamicReinforcementWest">
+            <English>Auto-enable reinforcement for WEST</English>
+        </Key>
+        <Key ID="STR_Lambs_Danger_Settings_DynamicReinforcementWest_ToolTip">
+            <English>Automatically enables LAMBS dynamic reinforcement on WEST groups when units initialize, including dynamically spawned units.</English>
+        </Key>
+        <Key ID="STR_Lambs_Danger_Settings_DynamicReinforcementEast">
+            <English>Auto-enable reinforcement for EAST</English>
+        </Key>
+        <Key ID="STR_Lambs_Danger_Settings_DynamicReinforcementEast_ToolTip">
+            <English>Automatically enables LAMBS dynamic reinforcement on EAST groups when units initialize, including dynamically spawned units.</English>
+        </Key>
+        <Key ID="STR_Lambs_Danger_Settings_DynamicReinforcementIndependent">
+            <English>Auto-enable reinforcement for INDEPENDENT</English>
+        </Key>
+        <Key ID="STR_Lambs_Danger_Settings_DynamicReinforcementIndependent_ToolTip">
+            <English>Automatically enables LAMBS dynamic reinforcement on INDEPENDENT groups when units initialize, including dynamically spawned units.</English>
+        </Key>
         <Key ID="STR_Lambs_Danger_Settings_GeneralCat">
             <English>General</English>
             <Czech>Všeobecné</Czech>


### PR DESCRIPTION
- Adds CBA options to enable dynamic reinforcement: Supports sandbox missions such as ALiVE via running when units spawn in, rather than at mission start (This may have a small performance impact in missions with large amounts of AI). This system is OFF by default.
- Adds CBA option to select maximum amount of groups called upon by the reinforcement system (0 by default, retaining original behaviour)